### PR TITLE
Add CropRegion

### DIFF
--- a/engine/crop.go
+++ b/engine/crop.go
@@ -90,15 +90,15 @@ func Crop(parent Quantity, x1, x2, y1, y2, z1, z2 int) *cropped {
 	util.Argument(x1 >= 0 && y1 >= 0 && z1 >= 0)
 	util.Argument(x2 <= n[X] && y2 <= n[Y] && z2 <= n[Z])
 
-	name := parent.Name()
+	name := parent.Name() + "_"
 	if x1 != 0 || x2 != n[X] {
-		name += "_xrange" + rangeStr(x1, x2)
+		name += "xrange" + rangeStr(x1, x2)
 	}
 	if y1 != 0 || y2 != n[Y] {
-		name += "_yrange" + rangeStr(y1, y2)
+		name += "yrange" + rangeStr(y1, y2)
 	}
 	if z1 != 0 || z2 != n[Z] {
-		name += "_zrange" + rangeStr(z1, z2)
+		name += "zrange" + rangeStr(z1, z2)
 	}
 
 	return &cropped{parent, name, x1, x2, y1, y2, z1, z2}

--- a/test/crop.mx3
+++ b/test/crop.mx3
@@ -42,6 +42,11 @@ expect("m3x", m3.Average()[0],  0.0, tol)
 expect("m3y", m3.Average()[1],  0.0, tol)
 expect("m3z", m3.Average()[2], -1.0, tol)
 
+m4 := CropRegion(m, 2)
+expect("m4x", m4.Average()[0],  0.0, tol)
+expect("m4y", m4.Average()[1],  0.0, tol)
+expect("m4z", m4.Average()[2], -1.0, tol)
+
 tableadd(m0)
 save(m0)
 tableadd(CropLayer(m.Comp(1), 2))


### PR DESCRIPTION
Wrapper for Crop that takes the smallest (x,y,z)-range that includes the specified region.

Also, naming for crop is modified, where previously when there are at least two ranges, there would be two underscores between them e.g. xrange33-55__yrange3-17. Now it is fixed to xrange33-55_yrange3-17.