### PR TITLE
nil the bufio.Writer to allow GC

### DIFF
--- a/httpfs/reader.go
+++ b/httpfs/reader.go
@@ -56,8 +56,15 @@ type bufWriter struct {
 }
 
 func (w *bufWriter) Write(p []byte) (int, error) { return w.buf.Write(p) }
-func (w *bufWriter) Close() error                { return w.buf.Flush() }
-func (w *bufWriter) Flush() error                { return w.buf.Flush() }
+func (w *bufWriter) Close() error {
+	err := w.buf.Flush()
+	w.buf = nil // Dangling pointer somewhere?
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (w *bufWriter) Flush() error { return w.buf.Flush() }
 
 type appendWriter struct {
 	URL       string


### PR DESCRIPTION
Fixes #55

I tried tracing references to this particular instance, but I don't see it being used other than as Out field of Process and the Stderr/Stdout field of the Command struct attached to the Cmd field in `cmd/mumax3-server/compute.go`.