### PR TITLE
using local magnetization instead of global

### DIFF
--- a/engine/magnetization.go
+++ b/engine/magnetization.go
@@ -30,7 +30,7 @@ func (m *magnetization) Type() reflect.Type      { return reflect.TypeOf(new(mag
 func (m *magnetization) Eval() interface{}       { return m }
 func (m *magnetization) average() []float64      { return sAverageMagnet(M.Buffer()) }
 func (m *magnetization) Average() data.Vector    { return unslice(m.average()) }
-func (m *magnetization) normalize()              { cuda.Normalize(M.Buffer(), geometry.Gpu()) }
+func (m *magnetization) normalize()              { cuda.Normalize(m.Buffer(), geometry.Gpu()) }
 
 // allocate storage (not done by init, as mesh size may not yet be known then)
 func (m *magnetization) alloc() {
@@ -43,7 +43,7 @@ func (b *magnetization) SetArray(src *data.Slice) {
 		src = data.Resample(src, b.Mesh().Size())
 	}
 	data.Copy(b.Buffer(), src)
-	M.normalize()
+	b.normalize()
 }
 
 func (m *magnetization) Set(c Config) {


### PR DESCRIPTION
This is irrelevant as of now, since there is only one magnetization object (?), but should be safer for possible future use.