### PR TITLE
Don't listen to the same IP multiple times

### DIFF
--- a/cmd/mumax3-server/main.go
+++ b/cmd/mumax3-server/main.go
@@ -72,6 +72,10 @@ func main() {
 	go func() {
 		log.Println("serving at", thisAddr)
 
+		// Resolve the IPs for thisHost
+		thisIP, err := net.LookupHost(thisHost)
+		Fatal(err)
+
 		// try to listen and serve on all interfaces other than thisAddr
 		// this is for convenience, errors are not fatal.
 		_, p, err := net.SplitHostPort(thisAddr)
@@ -79,8 +83,9 @@ func main() {
 		ips := util.InterfaceAddrs()
 		for _, ip := range ips {
 			addr := net.JoinHostPort(ip, p)
-			if addr != thisAddr { // skip thisAddr, will start later and is fatal on error
+			if !contains(thisIP, ip) { // skip thisIP, will start later and is fatal on error
 				go func() {
+					log.Println("serving at", addr)
 					err := http.ListenAndServe(addr, nil)
 					if err != nil {
 						log.Println("info:", err, "(but still serving other interfaces)")


### PR DESCRIPTION
Lookup the IP address of thisAddr to make sure we skip it when starting
servers on all interfaces. Otherwise there will be a race condition
where we start listening on all interfaces before the primary address.

Fix issue #113