### PR TITLE
Add ext_make3dgrains and testfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ mumax3.*linux*cuda*
 *.*~
 tmp/
 *.out
+.idea/

--- a/engine/ext_make3dgrains.go
+++ b/engine/ext_make3dgrains.go
@@ -22,7 +22,6 @@ func Voronoi3d(grainsize float64, startRegion int, numRegions int, inputShape Sh
 type tesselation3d struct {
 	grainsize   float64
 	maxRegion   int
-	seed        int64
 	rnd         *rand.Rand
 	startRegion int
 	shape       Shape			//Shape of the tesselated region
@@ -43,9 +42,7 @@ type cellLocs struct {x, y, z float64}
 func newTesselation3d(grainsize float64, nRegion int, seed int64, startRegion int, inputShape Shape) *tesselation3d {
 	t := tesselation3d{grainsize,
 		nRegion,
-		//make(map[int3d][]center3d),
-		seed,
-		rand.New(rand.NewSource(0)),
+		rand.New(rand.NewSource(seed)),
 		startRegion,
 		inputShape,
 		make([]center3d, 0)}
@@ -140,8 +137,6 @@ func (t *tesselation3d) RegionOf(x, y, z float64) int {
 	} else {
 		return -1	//When the regions are rendered, any region < 0 will not be rastered.
 	}
-
-
 }
 
 // Generate normally distributed numbers; mean = lambda, variance = lambda. If generated number < 0, return 1.

--- a/engine/ext_make3dgrains.go
+++ b/engine/ext_make3dgrains.go
@@ -1,0 +1,158 @@
+package engine
+
+import (
+	"math"
+	"math/rand"
+)
+
+func init() {
+	DeclFunc("ext_make3dgrains", Voronoi3d, "3D Voronoi tesselation over shape (grain size, starting region number, num regions, shape, seed)")
+}
+
+func Voronoi3d(grainsize float64, startRegion int, numRegions int, inputShape Shape, seed int) {
+	Refer("Lel2014")
+	SetBusy(true)
+	defer SetBusy(false)
+
+	t := newTesselation3d(grainsize, numRegions, int64(seed), startRegion, inputShape)
+	regions.hist = append(regions.hist, t.RegionOf)
+	regions.render(t.RegionOf)
+}
+
+type tesselation3d struct {
+	grainsize   float64
+	maxRegion   int
+	seed        int64
+	rnd         *rand.Rand
+	startRegion int
+	shape       Shape			//Shape of the tesselated region
+	centers     []center3d			//List of Voronoi centers
+}
+
+
+// Stores location of each Voronoi center
+type center3d struct {
+	x, y, z   float64 // center position (m)
+	region byte    // region for all cells near center
+}
+
+// Stores location of each cell
+type cellLocs struct {x, y, z float64}
+
+// nRegion exclusive
+func newTesselation3d(grainsize float64, nRegion int, seed int64, startRegion int, inputShape Shape) *tesselation3d {
+	t := tesselation3d{grainsize,
+		nRegion,
+		//make(map[int3d][]center3d),
+		seed,
+		rand.New(rand.NewSource(0)),
+		startRegion,
+		inputShape,
+		make([]center3d, 0)}
+
+	t.makeRandomCenters()
+	return &t
+}
+
+// Permutes the slice of cell locations. I don't understand why this needs to be done if we're choosing
+// random (Intn()) cells out of the slice of cell locations, but hey, it seems to do the trick.
+func shuffleCells(src []cellLocs) []cellLocs {
+	dest := make([]cellLocs, len(src))
+	perm := rand.Perm(len(src))
+	for i, v := range perm {
+		dest[v] = src[i]
+	}
+	return dest
+}
+
+
+func (t *tesselation3d) makeRandomCenters() {
+	//Make a list of all the cells in the shape.
+	cells := t.tabulateCells()
+	cells = shuffleCells(cells)
+
+	//Choose number of grains to make. Assume volume of grain is given by (4/3)*pi*r^3
+	shapeVolume := cellVolume()*float64(len(cells))
+	grainVolume := (float64(1)/6)*math.Pi*t.grainsize*t.grainsize*t.grainsize
+	nAvgGrains := shapeVolume/grainVolume
+	nGrains := t.truncNorm(nAvgGrains)
+
+	//TODO: same cell can be chosen twice by random chance
+	t.centers = make([]center3d, nGrains)
+	for p := 0; p<nGrains; p++ {
+		rndCell := cells[t.rnd.Intn(nGrains)]
+		t.centers[p].x = rndCell.x
+		t.centers[p].y = rndCell.y
+		t.centers[p].z = rndCell.z
+		randRegion := t.startRegion+t.rnd.Intn(t.maxRegion)
+		t.centers[p].region = byte(randRegion)
+	}
+
+	return
+}
+
+// Creates a slice of all cells which fall in the shape specified in the constructor.
+func (t *tesselation3d) tabulateCells() []cellLocs {
+	//Initialze array of cells
+	cells := make([]cellLocs, 0)
+
+	//Get the mesh size
+	meshSize := MeshSize()
+
+	//Iterate across all cells in the mesh, and append those that are inside the shape
+	for ix := 0; ix<meshSize[0]; ix++ {
+		for iy := 0; iy<meshSize[1]; iy++ {
+			for iz := 0; iz<meshSize[2]; iz++ {
+
+				cell := Index2Coord(ix, iy, iz)
+
+				x := cell.X()
+				y := cell.Y()
+				z := cell.Z()
+
+				if t.shape(x, y, z) {
+					cells = append(cells, cellLocs{x, y, z})
+				}
+			}
+		}
+	}
+
+	print("Number of cells in region: ", len(cells), "\n")
+	print("Number of cells in universe: ", meshSize[0]*meshSize[1]*meshSize[2], "\n")
+
+	return cells
+}
+
+// Find the nearest Voronoi center to the point (x, y, z). Only points inside the given shape will be
+// assigned a region.
+func (t *tesselation3d) RegionOf(x, y, z float64) int {
+	if t.shape(x, y, z) {
+		nearest := center3d{x, y, z, 0}
+		mindist := math.Inf(1)
+		for _, c := range t.centers {
+			dist := sqr(x-c.x) + sqr(y-c.y) + sqr(z-c.z)
+			if dist < mindist {
+				nearest = c
+				mindist = dist
+			}
+		}
+		return int(nearest.region)
+	} else {
+		return -1	//When the regions are rendered, any region < 0 will not be rastered.
+	}
+
+
+}
+
+// Generate normally distributed numbers; mean = lambda, variance = lambda. If generated number < 0, return 1.
+// Equivalent to Poisson distribution (with  mean = lambda) for large lambda (which is usually true, since the volume
+// of a grain is usually much less than the simulation volume.
+func (t *tesselation3d) truncNorm(lambda float64) int {
+	ret := lambda + math.Sqrt(lambda)*t.rnd.NormFloat64()
+	if ret <= 0 {
+		return 1
+	} else {
+		return int(ret + 0.5)
+	}
+
+}

--- a/test/make3dgrains.mx3
+++ b/test/make3dgrains.mx3
@@ -1,0 +1,32 @@
+nxyz := 64
+cellsize := 4e-9
+SetGridsize(nxyz, nxyz, nxyz)
+SetCellsize(cellsize, cellsize, cellsize)
+
+topblock := cuboid(cellsize*16,cellsize*16,cellsize*32).transl(0,0,cellsize*16)
+bottomlayer := zrange(-0.5,0*nxyz*cellsize)
+setgeom(topblock.add(bottomlayer))
+
+
+ext_make3dgrains(20e-9, 100, 100, topblock, 123)
+
+defregion(10, bottomlayer)
+
+
+m = uniform(0.5,0.5,0)
+K := 1e5
+for i:=100; i<200; i+=1 {
+	anisU.setregion(i, vector(randNorm()*0.1,randNorm()*0.1,1+randNorm()*0.1))
+	ku1.setregion(i, K+randNorm()*0.1*K)
+}
+
+//Scale the exchange interaction between all grains
+for i:=1; i<255; i+=1 {
+	for j:=i; j<255; j+=1 {
+		ext_scaleExchange(i,j,0.9)
+	}
+}
+
+save(regions)
+save(ku1)
+save(anisU)


### PR DESCRIPTION
Added an extension which allows for 3d Voronoi tesselation. It allows the user to choose grain size, specify which region numbers to use for the tesselation, as well as the specific shape inside your simulation space to tesselate. I included an example where part of the space is broken into Voronoi cells, and another part is left as a single uniform layer.