### PR TITLE
Log output from failed jobs

### DIFF
--- a/cmd/mumax3/queue.go
+++ b/cmd/mumax3/queue.go
@@ -123,9 +123,10 @@ func run(inFile string, gpu int, webAddr string) {
 
 	cmd := exec.Command(os.Args[0], flags...)
 	log.Println(os.Args[0], flags)
-	err := cmd.Run()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Println(inFile, err)
+		log.Printf("%s\n", output)
 		exitStatus.set(1)
 		numFailed.inc()
 		if *flag_failfast {


### PR DESCRIPTION
When running multiple jobs in queue, log the output of failing jobs.

Fixes #137 