### PR TITLE
fixed cuda version statement

### DIFF
--- a/cuda/cu/version.go
+++ b/cuda/cu/version.go
@@ -3,14 +3,17 @@ package cu
 // This file implements CUDA driver version management
 
 //#include <cuda.h>
+//#include <cuda_runtime_api.h>
 import "C"
 
 // Returns the CUDA driver version.
 func Version() int {
-	var version C.int
-	err := Result(C.cuDriverGetVersion(&version))
-	if err != SUCCESS {
-		panic(err)
-	}
-	return int(version)
+        var version C.int
+        err := Result(C.cuDriverGetVersion(&version))
+        if err != SUCCESS {
+                panic(err)
+        }
+        cu_version := Result(C.CUDART_VERSION)
+        return int(cu_version)
 }
+

--- a/cuda/cu/version.go
+++ b/cuda/cu/version.go
@@ -2,18 +2,10 @@ package cu
 
 // This file implements CUDA driver version management
 
-//#include <cuda.h>
 //#include <cuda_runtime_api.h>
 import "C"
 
 // Returns the CUDA driver version.
 func Version() int {
-        var version C.int
-        err := Result(C.cuDriverGetVersion(&version))
-        if err != SUCCESS {
-                panic(err)
-        }
-        cu_version := Result(C.CUDART_VERSION)
-        return int(cu_version)
+	return int(C.CUDART_VERSION)
 }
-


### PR DESCRIPTION
When compiling the binaries for older CUDA versions I noticed that mumax does not print the CUDA version actually used, but that cu_GetDriverVersion, actually prints the highest CUDA version supported by the driver. Was this intentional? If not, these changes allow mumax to print the actual CUDA version.