### PR TITLE
Fix bug in fft for odd Nx and pbc

### DIFF
--- a/cuda/fft3dc2r.go
+++ b/cuda/fft3dc2r.go
@@ -46,7 +46,7 @@ func (p *fft3DC2RPlan) ExecAsync(src, dst *data.Slice) {
 
 // 3D size of the input array.
 func (p *fft3DC2RPlan) InputSizeFloats() (Nx, Ny, Nz int) {
-	return p.size[X] + 2, p.size[Y], p.size[Z]
+	return 2 * (p.size[X]/2 + 1), p.size[Y], p.size[Z]
 }
 
 // 3D size of the output array.

--- a/cuda/fft3dr2c.go
+++ b/cuda/fft3dr2c.go
@@ -53,7 +53,7 @@ func (p *fft3DR2CPlan) InputSizeFloats() (Nx, Ny, Nz int) {
 
 // 3D size of the output array.
 func (p *fft3DR2CPlan) OutputSizeFloats() (Nx, Ny, Nz int) {
-	return p.size[X] + 2, p.size[Y], p.size[Z]
+	return 2 * (p.size[X]/2 + 1), p.size[Y], p.size[Z]
 }
 
 // Required length of the (1D) input array.

--- a/test/demag2Dpbc2.mx3
+++ b/test/demag2Dpbc2.mx3
@@ -24,6 +24,32 @@
 	expect("kzy", B_demag.Average()[1], 0, 1e-9)
 	expect("kzz", B_demag.Average()[2], -1, 2e-2) // not perfectly -1, finite film
 
+/*
+ 	Repeat the above with an odd number of cells along x.
+        This led to a fft size mismatch panic in mumax3.10 and before.
+*/
+
+	SetPBC(32, 0, 0)
+	SetGridSize(3, 128, 1)
+	SetCellSize(1e-9, 1e-9, 0.5e-9)
+
+	Msat = 1 / mu0
+
+	m = uniform(1, 0, 0)
+	expect("kxx", B_demag.Average()[0], 0, 1e-2) // not perfectly 0, finite film
+	expect("kxy", B_demag.Average()[1], 0, 1e-9)
+	expect("kxz", B_demag.Average()[2], 0, 1e-9)
+
+	m = uniform(0, 1, 0)
+	expect("kyx", B_demag.Average()[0], 0, 1e-9)
+	expect("kyy", B_demag.Average()[1], 0, 1e-2) // not perfectly 0, finite film
+	expect("kyz", B_demag.Average()[2], 0, 1e-9)
+
+	m = uniform(0, 0, 1)
+	expect("kzx", B_demag.Average()[0], 0, 1e-9)
+	expect("kzy", B_demag.Average()[1], 0, 1e-9)
+	expect("kzz", B_demag.Average()[2], -1, 2e-2) // not perfectly -1, finite film
+
 
 
 


### PR DESCRIPTION
This pull request fixes the data layout of the r2c and c2r ffts for odd kernel sizes along X.

This solves the bug mentioned in #74.