### PR TITLE
Flush cache buffers before run

### DIFF
--- a/engine/minimizer.go
+++ b/engine/minimizer.go
@@ -57,6 +57,12 @@ type Minimizer struct {
 func (mini *Minimizer) Step() {
 	m := M.Buffer()
 	size := m.Size()
+
+	if mini.k == nil {
+		mini.k = cuda.Buffer(3, size)
+		torqueFn(mini.k)
+	}
+
 	k := mini.k
 	h := mini.h
 
@@ -110,7 +116,7 @@ func (mini *Minimizer) Step() {
 }
 
 func (mini *Minimizer) Free() {
-	cuda.Recycle(mini.k)
+	mini.k.Free()
 }
 
 func Minimize() {
@@ -141,15 +147,11 @@ func Minimize() {
 	}
 
 	// set stepper to the minimizer
-	size := M.Buffer().Size()
 	mini := Minimizer{
 		h:      1e-4,
-		k:      cuda.Buffer(3, size),
+		k:      nil,
 		lastDm: FifoRing(DmSamples)}
 	stepper = &mini
-
-	// calculate initial torque
-	torqueFn(mini.k)
 
 	cond := func() bool {
 		return (mini.lastDm.count < DmSamples || mini.lastDm.Max() > StopMaxDm)

--- a/engine/run.go
+++ b/engine/run.go
@@ -172,6 +172,7 @@ func RunWhile(condition func() bool) {
 	SanityCheck()
 	pause = false // may be set by <-Inject
 	const output = true
+	stepper.Free() // start from a clean state
 	runWhile(condition, output)
 	pause = true
 }

--- a/test/steppercache.mx3
+++ b/test/steppercache.mx3
@@ -1,0 +1,27 @@
+/*
+    Test if the stepper cache buffers are flushed when starting a new run
+*/
+
+setgridsize(1,1,1)
+setcellsize(1,1,1)
+
+msat = 1000e3
+alpha = 0.1
+B_ext = vector(0, 0, 0.05)
+
+setsolver(5) // This steppers uses a cache buffer
+fixdt = 1e-12
+
+m = uniform(1,0,0)
+steps(1)
+rotation_wanted := acos( vector(1,0,0).dot(m.average()) )
+
+m = uniform(-1,0,0)
+steps(1)
+rotation := acos( vector(-1,0,0).dot(m.average()) )
+
+// Note that the rotation angle should be the same for the two cases for symmetry reasons.
+// However, if the cache buffers are not removed, this will lead to an erroneous result in
+// the second case.
+
+expect("m rotation angle", rotation, rotation_wanted, 1e-5)


### PR DESCRIPTION
Before running the stepper, the cache buffers of the stepper will be flushed. This avoids the possibility of an erroneous first step (issue #260).

To make this work, the minimizer is slightly adapted so that it can start from a clean state.
