### PR TITLE
Add GPL-3 exception for linking to NVidia's CUDA libraries

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -12,6 +12,15 @@ but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
+Additional permission under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or
+combining it with NVIDIA Corporation's CUDA libraries from the
+NVIDIA CUDA Toolkit (or a modified version of those libraries),
+containing parts covered by the terms of NVIDIA CUDA Toolkit
+EULA, the licensors of this Program grant you additional
+permission to convey the resulting work.
+
 Mumax3 uses svgo (http://github.com/ajstarks/svgo), copyright Anthony Starks,
 licensed under the Creative Commons Attribution 3.0 license 
 as described in http://creativecommons.org/licenses/by/3.0/us/ .


### PR DESCRIPTION
I believe the LICENSE file is incomplete, as it doesn't really allow redistributing mumax3 when it's linked to NVidia's libraries. The suggested patch should fix this.