### PR TITLE
Feature/regionwise gammaLL

### DIFF
--- a/cuda/constants.h
+++ b/cuda/constants.h
@@ -5,7 +5,9 @@
 #define MU0    (4*PI*1e-7)        // Permeability of vacuum in Tm/A
 #define QE     1.60217646E-19     // Electron charge in C
 #define MUB    9.2740091523E-24   // Bohr magneton in J/T
-#define GAMMA0 1.7595e11          // Gyromagnetic ratio of electron, in rad/Ts
+// GAMMA0 should NOT be used. It is a user definable parameter, not constant!
+// Anyway, now we implement the region-wise g. It was only used in zhangli.cu
+//#define GAMMA0 1.7595e11          // Gyromagnetic ratio of electron, in rad/Ts
 #define HBAR   1.05457173E-34
 
 #endif

--- a/cuda/lltorque.go
+++ b/cuda/lltorque.go
@@ -20,6 +20,16 @@ func LLTorque(torque, m, B *data.Slice, alpha MSlice) {
 		alpha.DevPtr(0), alpha.Mul(0), N, cfg)
 }
 
+// Scale up the torques by GFactor (to allow regionwise g)
+func ScaleGamma(torque *data.Slice, GFactor MSlice) {
+	N := torque.Len()
+	cfg := make1DConf(N)
+
+	k_scalegamma_async(torque.DevPtr(X), torque.DevPtr(Y), torque.DevPtr(Z),
+                GFactor.DevPtr(0), GFactor.Mul(0), N, cfg)
+
+}
+
 // Landau-Lifshitz torque with precession disabled.
 // Used by engine.Relax().
 func LLNoPrecess(torque, m, B *data.Slice) {

--- a/cuda/scalegamma.cu
+++ b/cuda/scalegamma.cu
@@ -1,0 +1,17 @@
+#include "amul.h"
+#include "float3.h"
+#include <stdint.h>
+
+// scale torque by scalar parameter GammaFactor
+extern "C" __global__ void
+scalegamma(float* __restrict__  tx, float* __restrict__  ty, float* __restrict__  tz,
+          float* __restrict__  scalegamma_, float scalegamma_mul, int N) {
+
+    int i =  ( blockIdx.y*gridDim.x + blockIdx.x ) * blockDim.x + threadIdx.x;
+    if (i < N) {
+        float gammaf = amul(scalegamma_, scalegamma_mul,i);
+        tx[i] = tx[i]*gammaf;
+        ty[i] = ty[i]*gammaf;
+        tz[i] = tz[i]*gammaf;
+    }
+}

--- a/cuda/temperature.go
+++ b/cuda/temperature.go
@@ -7,7 +7,7 @@ import (
 
 // Set Bth to thermal noise (Brown).
 // see temperature.cu
-func SetTemperature(Bth, noise *data.Slice, k2mu0_Mu0VgammaDt float64, Msat, Temp, Alpha MSlice) {
+func SetTemperature(Bth, noise *data.Slice, k2mu0_Mu0VgammaDt float64, Msat, Temp, Alpha, g MSlice) {
 	util.Argument(Bth.NComp() == 1 && noise.NComp() == 1)
 
 	N := Bth.Len()
@@ -17,5 +17,6 @@ func SetTemperature(Bth, noise *data.Slice, k2mu0_Mu0VgammaDt float64, Msat, Tem
 		Msat.DevPtr(0), Msat.Mul(0),
 		Temp.DevPtr(0), Temp.Mul(0),
 		Alpha.DevPtr(0), Alpha.Mul(0),
+		g.DevPtr(0), g.Mul(0),
 		N, cfg)
 }

--- a/cuda/temperature2.cu
+++ b/cuda/temperature2.cu
@@ -7,6 +7,7 @@ settemperature2(float* __restrict__  B,      float* __restrict__ noise, float kB
                 float* __restrict__ Ms_, float Ms_mul,
                 float* __restrict__ temp_, float temp_mul,
                 float* __restrict__ alpha_, float alpha_mul,
+                float* __restrict__ g_, float g_mul,
                 int N) {
 
     int i =  ( blockIdx.y*gridDim.x + blockIdx.x ) * blockDim.x + threadIdx.x;
@@ -14,7 +15,7 @@ settemperature2(float* __restrict__  B,      float* __restrict__ noise, float kB
         float invMs = inv_Msat(Ms_, Ms_mul, i);
         float temp = amul(temp_, temp_mul, i);
         float alpha = amul(alpha_, alpha_mul, i);
-        B[i] = noise[i] * sqrtf((kB2_VgammaDt * alpha * temp * invMs ));
+        float g = amul(g_, g_mul, i);
+        B[i] = noise[i] * sqrtf((kB2_VgammaDt * alpha * temp * invMs / g));
     }
 }
-

--- a/cuda/zhangli.go
+++ b/cuda/zhangli.go
@@ -6,7 +6,7 @@ import (
 
 // Add Zhang-Li ST torque (Tesla) to torque.
 // see zhangli.cu
-func AddZhangLiTorque(torque, m *data.Slice, Msat, J, alpha, xi, pol MSlice, mesh *data.Mesh) {
+func AddZhangLiTorque(torque, m *data.Slice, Msat, J, alpha, xi, pol, g MSlice, mesh *data.Mesh) {
 	c := mesh.CellSize()
 	N := mesh.Size()
 	cfg := make3DConf(N)
@@ -21,6 +21,7 @@ func AddZhangLiTorque(torque, m *data.Slice, Msat, J, alpha, xi, pol MSlice, mes
 		alpha.DevPtr(0), alpha.Mul(0),
 		xi.DevPtr(0), xi.Mul(0),
 		pol.DevPtr(0), pol.Mul(0),
+		g.DevPtr(0), g.Mul(0),
 		float32(c[X]), float32(c[Y]), float32(c[Z]),
 		N[X], N[Y], N[Z], mesh.PBC_code(), cfg)
 }

--- a/cuda/zhangli.go
+++ b/cuda/zhangli.go
@@ -6,7 +6,7 @@ import (
 
 // Add Zhang-Li ST torque (Tesla) to torque.
 // see zhangli.cu
-func AddZhangLiTorque(torque, m *data.Slice, Msat, J, alpha, xi, pol, g MSlice, mesh *data.Mesh) {
+func AddZhangLiTorque(torque, m *data.Slice, Msat, J, alpha, xi, pol, g MSlice, gammaLL float32, mesh *data.Mesh) {
 	c := mesh.CellSize()
 	N := mesh.Size()
 	cfg := make3DConf(N)
@@ -21,7 +21,7 @@ func AddZhangLiTorque(torque, m *data.Slice, Msat, J, alpha, xi, pol, g MSlice, 
 		alpha.DevPtr(0), alpha.Mul(0),
 		xi.DevPtr(0), xi.Mul(0),
 		pol.DevPtr(0), pol.Mul(0),
-		g.DevPtr(0), g.Mul(0),
+		g.DevPtr(0), g.Mul(0)*gammaLL,
 		float32(c[X]), float32(c[Y]), float32(c[Z]),
 		N[X], N[Y], N[Z], mesh.PBC_code(), cfg)
 }

--- a/cuda/zhangli2.cu
+++ b/cuda/zhangli2.cu
@@ -4,7 +4,8 @@
 #include "stencil.h"
 #include <stdint.h>
 
-#define PREFACTOR ((MUB) / (2 * QE * GAMMA0))
+// #define PREFACTOR ((MUB) / (2 * QE * GAMMA0))
+#define PREFACTOR ((HBAR) / (2 * QE))
 
 // spatial derivatives without dividing by cell size
 #define deltax(in) (in[idx(hclampx(ix+1), iy, iz)] - in[idx(lclampx(ix-1), iy, iz)])
@@ -21,6 +22,7 @@ addzhanglitorque2(float* __restrict__ tx, float* __restrict__ ty, float* __restr
                   float* __restrict__ alpha_, float alpha_mul,
                   float* __restrict__ xi_, float xi_mul,
                   float* __restrict__ pol_, float pol_mul,
+                  float* __restrict__ g_, float g_mul,
                   float cx, float cy, float cz,
                   int Nx, int Ny, int Nz, uint8_t PBC) {
 
@@ -37,8 +39,9 @@ addzhanglitorque2(float* __restrict__ tx, float* __restrict__ ty, float* __restr
     float alpha = amul(alpha_, alpha_mul, i);
     float xi    = amul(xi_, xi_mul, i);
     float pol   = amul(pol_, pol_mul, i);
+    float g     = amul(g_, g_mul, i);
     float invMs = inv_Msat(Ms_, Ms_mul, i);
-    float b = invMs * PREFACTOR / (1.0f + xi*xi);
+    float b = invMs * PREFACTOR / (g*(1.0f + xi*xi));
     float3 J = pol*vmul(jx_, jy_, jz_, jx_mul, jy_mul, jz_mul, i);
 
     float3 hspin = make_float3(0.0f, 0.0f, 0.0f); // (u·∇)m
@@ -62,4 +65,3 @@ addzhanglitorque2(float* __restrict__ tx, float* __restrict__ ty, float* __restr
     ty[i] += torque.y;
     tz[i] += torque.z;
 }
-

--- a/engine/temperature.go
+++ b/engine/temperature.go
@@ -100,9 +100,11 @@ func (b *thermField) update() {
 	defer temp.Recycle()
 	alpha := Alpha.MSlice()
 	defer alpha.Recycle()
+	g := GFactor.MSlice()
+	defer g.Recycle()
 	for i := 0; i < 3; i++ {
 		b.generator.GenerateNormal(uintptr(noise.DevPtr(0)), int64(N), mean, stddev)
-		cuda.SetTemperature(dst.Comp(i), noise, k2_VgammaDt, ms, temp, alpha)
+		cuda.SetTemperature(dst.Comp(i), noise, k2_VgammaDt, ms, temp, alpha, g)
 	}
 
 	b.step = NSteps


### PR DESCRIPTION
This commit implements a regionwise gyromagnetic factor (gammaLL). For backwards-compatibility reasons, this is done with an additional user-accessible parameter, GFactor (default value 1.0). The material's gyromagnetic factor is then the product of the global parameter gammaLL and the region-wise parameter GFactor.

Additionally, a bug was corrected in the calculation of the Zhang-Li torque. Previously, cuda/zhangli.cu used a hard-wired value of gamma (defined in cuda/constants.h), which leads to a wrong calculation in simulations where the user changes the value of GammaLL.


### Further improvements

It would perhaps be more elegant to leave only a single parameter user accessible (the region-wise one). But GammaLL is used internally by Mumax3 to normalise the timestep, and so a global parameter with a value of the order of 1.76e11 is required, even if it could be hidden from the user. The solution could be to set gammaLL to mu_B/hbar=0.879e11 and use GFactor as the Landé g-factor (default value 2.0), but this would not be backwards compatible.


### Modifications

1. Removal of ‘submarine’ definition of the gyromagnetic ratio GAMMA0 (defined in constants.h and used in zhangli.cu). Changed zhangli to use the user-defined gammaLL. Affected files: 

- 3/cuda/constants.h
- 3/cuda/zhangli.go
- 3/cuda/zhangli2.cu

2. Added gFactor as a region-wise user parameter. The physical gamma is GammaLL*gFactor. Torques are scaled up by gFactor. Affected files:

- 3/engine/torque.go
- 3/engine/temperature.go
- 3/engine/torque.go
- 3/cuda/lltorque.go (added a wrapper function for scalegamma.cu)
- 3/cuda/scalegamma.cu (added. Cuda kernel to multiply  the torque Slice with a gFactor MSlice)

 
3. Changed the temperature to account for the region-wise scale factor of gamma. Affected files:

- 3/cuda/temperature.go
- 3/cuda/temperature2.cu
