### PR TITLE
Update magnetoelasticfield.cu

### DIFF
--- a/cuda/magnetoelasticfield.cu
+++ b/cuda/magnetoelasticfield.cu
@@ -44,9 +44,9 @@ addmagnetoelasticfield(float* __restrict__  Bx, float* __restrict__  By, float* 
 
 	    float3 m = {mx[I], my[I], mz[I]};
 
-	    Bx[I] += -(2.0f*B1*m.x*Exx + B2*(m.y*Exy + m.z*Exz));
-	    By[I] += -(2.0f*B1*m.y*Eyy + B2*(m.x*Eyx + m.z*Eyz));
-	    Bz[I] += -(2.0f*B1*m.z*Ezz + B2*(m.x*Ezx + m.y*Ezy));
+	    Bx[I] += -2.0f*(B1*m.x*Exx + B2*(m.y*Exy + m.z*Exz));
+	    By[I] += -2.0f*(B1*m.y*Eyy + B2*(m.x*Eyx + m.z*Eyz));
+	    Bz[I] += -2.0f*(B1*m.z*Ezz + B2*(m.x*Ezx + m.y*Ezy));
 	}
 }
 


### PR DESCRIPTION
The magnetoelastic energy is written as:

$$ E_{me} = B_1(E_{xx}m_{x}^2 + E_{yy}m_{y}^2 + E_{zz}m_{z}^2) + 2B_2(E_{xy}m_{x}m_{y}+E_{xz}m_{x}m_{z}+E_{yz}m_{y}m_{z}) $$

And the effective field is: $B_{me} = -\nabla_{m} E_{me}$
Therefore, for example, the effective field in $m_x$ would be:

$$ B_{me}^x = -2B_1 E_{xx}m_x + 2B_2( E_{xy}my  + E_{xz} m_z) $$


The article: https://doi.org/10.12688/openreseurope.13302.1 on page 4, equation 3, explains how the model is implemented and in this GitHub link you can find the code: https://github.com/Fredericvdv/Magnetoelasticity_MuMax3/blob/eeb112dff216a4ae3267fc27fe67aa0e7ada6423/cuda/magnetoelasticfield.cu

In this repository effective field terms are calculated correctly: 
```	    
            Bx[I] += -2.0f*(B1*m.x*Exx + B2*(m.y*Exy + m.z*Exz));
	    By[I] += -2.0f*(B1*m.y*Eyy + B2*(m.x*Eyx + m.z*Eyz));
	    Bz[I] += -2.0f*(B1*m.z*Ezz + B2*(m.x*Ezx + m.y*Ezy)); 
```

Where the 2.0f is multiplied by both B1 and B2. 
However, in the MuMax3 repository, I found:
```
	    Bx[I] += -(2.0f*B1*m.x*Exx + B2*(m.y*Exy + m.z*Exz));
	    By[I] += -(2.0f*B1*m.y*Eyy + B2*(m.x*Eyx + m.z*Eyz));
	    Bz[I] += -(2.0f*B1*m.z*Ezz + B2*(m.x*Ezx + m.y*Ezy));
```

The parenthesis should be after the 2.0f.

This Pull Request is to address this issue.

