### PR TITLE
Allow Nz=2,3,4,5 for MFM images

### DIFF
--- a/mag/mfmkernel.go
+++ b/mag/mfmkernel.go
@@ -3,11 +3,12 @@ package mag
 import (
 	"bufio"
 	"fmt"
+	"math"
+	"os"
+
 	d "github.com/mumax/3/data"
 	"github.com/mumax/3/oommf"
 	"github.com/mumax/3/util"
-	"math"
-	"os"
 )
 
 func MFMKernel(mesh *d.Mesh, lift, tipsize float64, cacheDir string) (kernel [3]*d.Slice) {
@@ -107,7 +108,7 @@ func CalcMFMKernel(mesh *d.Mesh, lift, tipsize float64) (kernel [3]*d.Slice) {
 		util.Assert(cellsize[X] > 0 && cellsize[Y] > 0 && cellsize[Z] > 0)
 		util.AssertMsg(size[X]%2 == 0 && size[Y]%2 == 0, "Even kernel size needed")
 		if size[Z] > 1 {
-			util.AssertMsg(size[Z]%2 == 0, "Even kernel size needed")
+			// util.AssertMsg(size[Z]%2 == 0, "Even kernel size needed")
 		}
 	}
 

--- a/mag/mfmkernel.go
+++ b/mag/mfmkernel.go
@@ -106,7 +106,7 @@ func CalcMFMKernel(mesh *d.Mesh, lift, tipsize float64) (kernel [3]*d.Slice) {
 	{
 		util.Assert(size[Z] >= 1 && size[Y] >= 2 && size[X] >= 2)
 		util.Assert(cellsize[X] > 0 && cellsize[Y] > 0 && cellsize[Z] > 0)
-		util.AssertMsg(size[X]%2 == 0 && size[Y]%2 == 0, "Even kernel size needed")
+		// util.AssertMsg(size[X]%2 == 0 && size[Y]%2 == 0, "Even kernel size needed")
 		if size[Z] > 1 {
 			// util.AssertMsg(size[Z]%2 == 0, "Even kernel size needed")
 		}

--- a/mag/mfmkernel.go
+++ b/mag/mfmkernel.go
@@ -107,9 +107,9 @@ func CalcMFMKernel(mesh *d.Mesh, lift, tipsize float64) (kernel [3]*d.Slice) {
 		util.Assert(size[Z] >= 1 && size[Y] >= 2 && size[X] >= 2)
 		util.Assert(cellsize[X] > 0 && cellsize[Y] > 0 && cellsize[Z] > 0)
 		// util.AssertMsg(size[X]%2 == 0 && size[Y]%2 == 0, "Even kernel size needed")
-		if size[Z] > 1 {
-			// util.AssertMsg(size[Z]%2 == 0, "Even kernel size needed")
-		}
+		// if size[Z] > 1 {
+		// util.AssertMsg(size[Z]%2 == 0, "Even kernel size needed")
+		// }
 	}
 
 	// Allocate only upper diagonal part. The rest is symmetric due to reciprocity.

--- a/test/mfm_sizes.mx3
+++ b/test/mfm_sizes.mx3
@@ -1,0 +1,27 @@
+/*
+	Checks if MFM images can be saved for all thicknesses with and without PBC.
+	There was once a bug (#93) where Nz=2,3,4,5 could not generate an MFM image.
+*/
+
+Nx := 64
+Ny := 64
+c := 4e-9
+
+Msat = 1/mu0
+Aex = 10e-12
+
+for Nz := 1; Nz < 12; Nz++ {
+	SetGridSize(Nx, Ny, Nz)
+	SetCellSize(c, c, c)
+	SetGeom(Zrange(-NZ*c/2, c/2).Intersect(Circle(Nx*c)))
+	m  = vortex(1, 1);
+	SetPBC(0, 0, 0)
+
+	SaveAs(m, sprintf("m_%d.ovf", Nz))
+	
+	MFMLift = 40e-9 // forces the calculation of the MFM kernel.
+	SnapshotAs(MFM, sprintf("MFM_%d.jpg", Nz))
+	SetPBC(2, 0, 0)
+	MFMLift = 40e-9 // forces the calculation of the MFM kernel.
+	SnapshotAs(MFM, sprintf("MFM_%d_PBC.jpg", Nz))
+}

--- a/test/mfm_sizes.mx3
+++ b/test/mfm_sizes.mx3
@@ -3,25 +3,25 @@
 	There was once a bug (#93) where Nz=2,3,4,5 could not generate an MFM image.
 */
 
-Nx := 64
+Nx := 63
 Ny := 64
 c := 4e-9
 
-Msat = 1/mu0
+Msat = 1 / mu0
 Aex = 10e-12
 
 for Nz := 1; Nz < 12; Nz++ {
 	SetGridSize(Nx, Ny, Nz)
 	SetCellSize(c, c, c)
-	SetGeom(Zrange(-NZ*c/2, c/2).Intersect(Circle(Nx*c)))
-	m  = vortex(1, 1);
+	SetGeom(Zrange(-NZ*c/2, c/2).Intersect(Circle(Nx * c).Add(Xrange(-c*Nx/4, c*Nx/4))))
+	m = vortex(1, 1)
 	SetPBC(0, 0, 0)
 
 	SaveAs(m, sprintf("m_%d.ovf", Nz))
-	
+
 	MFMLift = 40e-9 // forces the calculation of the MFM kernel.
 	SnapshotAs(MFM, sprintf("MFM_%d.jpg", Nz))
-	SetPBC(2, 0, 0)
+	SetPBC(2, 2, 0)
 	MFMLift = 40e-9 // forces the calculation of the MFM kernel.
 	SnapshotAs(MFM, sprintf("MFM_%d_PBC.jpg", Nz))
 }


### PR DESCRIPTION
This PR addresses issue #93.

It is unclear why the culprit, the now removed `AssertMsg` which checks if `Nz` is even, exists. Without it, all tests still run fine and MFM images still look as expected for the affected values of Nz.

There is another similar `AssertMsg` checking if `Nx` and `Ny` are even, but also for those everything seems to work as expected if the assert is deactivated. This is not yet included in the PR. Would it be safe to remove this too?