### PR TITLE
Feature/complete grains at shape edge

### DIFF
--- a/engine/ext_make3dgrains.go
+++ b/engine/ext_make3dgrains.go
@@ -7,11 +7,11 @@ import (
 	"math/rand"
 )
 
-var CompleteGrainsAtShapeEdge  = false // complete the voronoi grains  instead of cutting them off at the shape edge
+var GrainCutShape  = false // complete all voronoi grains whose centre lies within the shape. Warning, this also cuts away parts of the shape whose closest voronoi centre lies outside the shape
 
 func init() {
 	DeclFunc("ext_make3dgrains", Voronoi3d, "3D Voronoi tesselation over shape (grain size, starting region number, num regions, shape, seed)")
-	DeclVar("CompleteGrainsAtShapeEdge", &CompleteGrainsAtShapeEdge, "Enables completion of grains beyond shape edge (default=false)")
+	DeclVar("GrainCutShape", &GrainCutShape, "Adds the complete voronoi grain, if its centre lies within the shape  (default=false)")
 }
 
 func Voronoi3d(grainsize float64, startRegion int, numRegions int, inputShape Shape, seed int) {
@@ -110,7 +110,7 @@ func (t *tesselation3d) tabulateCells() []cellLocs {
 				y := cell.Y()
 				z := cell.Z()
 
-				if (t.shape(x, y, z)|| CompleteGrainsAtShapeEdge) {
+				if (t.shape(x, y, z)|| GrainCutShape) {
 					cells = append(cells, cellLocs{x, y, z})
 				}
 			}
@@ -125,8 +125,8 @@ func (t *tesselation3d) tabulateCells() []cellLocs {
 
 
 func (t *tesselation3d) RegionOf(x, y, z float64) int {
-    // Check if the point is within the shape or edge grains should be completed
-    if !(t.shape(x, y, z) || CompleteGrainsAtShapeEdge) {
+    // Check if the point is within the shape or if we're cutting the shape along the grains 
+    if !(t.shape(x, y, z) || GrainCutShape) {
         return -1 // Regions < 0 won't be rastered
     }
 
@@ -142,7 +142,7 @@ func (t *tesselation3d) RegionOf(x, y, z float64) int {
     }
 
     // Check if the nearest point's region should be returned
-    if t.shape(x, y, z) || (t.shape(nearest.x, nearest.y, nearest.z) && CompleteGrainsAtShapeEdge) {
+    if t.shape(x, y, z) || (t.shape(nearest.x, nearest.y, nearest.z) && GrainCutShape) {
         return int(nearest.region)
     }
 

--- a/test/make3dgrains_shape_edge.mx3
+++ b/test/make3dgrains_shape_edge.mx3
@@ -14,7 +14,7 @@ defregion(1, sphere)
 
 seed:=238948790
 randSeed(seed) 
-CompleteGrainsAtShapeEdge=true
+GrainCutShape=true
 ext_make3Dgrains(8e-9, 2, 250, sphere, seed)
 
 for i:=2; i<254; i+=1 {

--- a/test/make3dgrains_shape_edge.mx3
+++ b/test/make3dgrains_shape_edge.mx3
@@ -1,0 +1,32 @@
+N:=32
+SetMesh(N, N, N, 1e-9,1e-9,1e-9, 0, 0, 0)
+
+//set material params
+alpha=1.
+Msat=350e3
+Aex=10e-12
+Ku1=1.0e6
+
+//define a spherical shape 
+diam:=16e-9
+sphere := Ellipsoid(diam,diam,diam)
+defregion(1, sphere)
+
+seed:=238948790
+randSeed(seed) 
+CompleteGrainsAtShapeEdge=true
+ext_make3Dgrains(8e-9, 2, 250, sphere, seed)
+
+for i:=2; i<254; i+=1 {
+	anisU.setregion(i, vector(randNorm(),randNorm(),randNorm()))
+}
+
+
+//a cell in the sphere for which the nearest voronoi centre also lies in the sphere:  nonzero region nr expected
+expect("region", regions.getcell(15,15,15), 174, 0)
+
+//a cell in the sphere for which the nearest voronoi centre lies outside the sphere: region nr 1 expected as it is not affected by make3Dgrains
+expect("region", regions.getcell(19,19,15), 1, 0)
+
+//a cell outside of the sphere for which the neares voronoi centre lies inside the sphere: nonzero region nr expected as it was completed by make3Dgrains
+expect("region", regions.getcell(15,6,15), 224, 0)


### PR DESCRIPTION
Adds a variable to ext_make3dgrains to complete all voronoi grains whose centre lies within the shape. This also cuts away parts of the shape whose closest voronoi centre lies outside the shape.

This allows e.g. to make polycrystalline geometries consisting of clustered individual grains.

![clusterparticle](https://github.com/user-attachments/assets/050566a3-67e4-447c-a106-3781e437d83b)
