### PR TITLE
Warn the user when choice of grid size can cause a CUDA error

### DIFF
--- a/engine/mesh.go
+++ b/engine/mesh.go
@@ -43,7 +43,7 @@ func SetMesh(Nx, Ny, Nz int, cellSizeX, cellSizeY, cellSizeZ float64, pbcx, pbcy
 
 	warnStr := "// WARNING: %s-axis is not 7-smooth. It has %d cells, with prime\n" +
 		"//          factors %v, at least one of which is greater than 7.\n" +
-		"//          This may reduce performance or cause a GPU error." // Error is likely when the largest factor is >127
+		"//          This may reduce performance or cause a CUDA_ERROR_INVALID_VALUE error." // Error is likely when the largest factor is >127
 	if factorsx := primeFactors(Nx); slices.Max(factorsx) > 7 {
 		util.Log(fmt.Sprintf(warnStr, "x", Nx, factorsx))
 	}

--- a/engine/mesh.go
+++ b/engine/mesh.go
@@ -1,8 +1,12 @@
 package engine
 
 import (
+	"fmt"
+	"slices"
+
 	"github.com/mumax/3/cuda"
 	"github.com/mumax/3/data"
+	"github.com/mumax/3/util"
 )
 
 var globalmesh_ data.Mesh // mesh for m and everything that has the same size
@@ -36,6 +40,19 @@ func SetMesh(Nx, Ny, Nz int, cellSizeX, cellSizeY, cellSizeZ float64, pbcx, pbcy
 	arg("GridSize", Nx > 0 && Ny > 0 && Nz > 0)
 	arg("CellSize", cellSizeX > 0 && cellSizeY > 0 && cellSizeZ > 0)
 	arg("PBC", pbcx >= 0 && pbcy >= 0 && pbcz >= 0)
+
+	warnStr := "// WARNING: %s-axis is not 7-smooth. It has %d cells, with prime\n" +
+		"//          factors %v, at least one of which is greater than 7.\n" +
+		"//          This may reduce performance or cause a GPU error." // Error is likely when the largest factor is >127
+	if factorsx := primeFactors(Nx); slices.Max(factorsx) > 7 {
+		util.Log(fmt.Sprintf(warnStr, "x", Nx, factorsx))
+	}
+	if factorsy := primeFactors(Ny); slices.Max(factorsy) > 7 {
+		util.Log(fmt.Sprintf(warnStr, "y", Ny, factorsy))
+	}
+	if factorsz := primeFactors(Nz); slices.Max(factorsz) > 7 {
+		util.Log(fmt.Sprintf(warnStr, "z", Nz, factorsz))
+	}
 
 	sizeChanged := globalmesh_.Size() != [3]int{Nx, Ny, Nz}
 	cellSizeChanged := globalmesh_.CellSize() != [3]float64{cellSizeX, cellSizeY, cellSizeZ}

--- a/engine/util.go
+++ b/engine/util.go
@@ -167,6 +167,25 @@ func paramDiv(dst, a, b [][NREGION]float32) {
 	}
 }
 
+// returns an array with the prime factors of n (n >= 1)
+func primeFactors(n int) (factors []int) {
+	util.AssertMsg(n >= 1, "Can only determine prime factors of a positive integer.")
+	for n%2 == 0 { // First, get all factors 2
+		factors = append(factors, 2)
+		n = n / 2
+	}
+	for i := 3; i*i <= n; i = i + 2 { // Since n is odd now, we can skip even divisors
+		for n%i == 0 { // while i divides n, append i and divide n
+			factors = append(factors, i)
+			n = n / i
+		}
+	}
+	if n > 1 || len(factors) == 0 { // Add any remaining factor
+		factors = append(factors, n)
+	}
+	return
+}
+
 // shortcut for slicing unaddressable_vector()[:]
 func slice(v [3]float64) []float64 {
 	return v[:]


### PR DESCRIPTION
This PR adds warnings for two situations where the choice of grid size could result in a CUDA error.

1) #284 
    When the number of cells along an axis has a prime factor >127, the `CUDA_ERROR_INVALID_VALUE` error occurs because of the [inner workings of the cuFFT algorithm](https://docs.nvidia.com/cuda/cufft/index.html?highlight=cooley%2520tukey#accuracy-and-performance) (see [@jplauzie's reply](https://github.com/mumax/3/issues/314#issuecomment-1278507776)).

    The new warning (example below) is already raised when the grid is not 7-smooth, i.e. when there is a prime factor greater than 7. This includes the >127 case, while also raising awareness about the recommendation to use a 7-smooth grid.
    ```
    // WARNING: y-axis is not 7-smooth. It has 501 cells, with prime
    //          factors [3 167], at least one of which is greater than 7.
    //          This may reduce performance or cause a CUDA_ERROR_INVALID_VALUE error.
    ```

2) #314 
    When temperature is nonzero, and the grid contains an odd number of cells, the `CURAND_STATUS_LENGTH_NOT_MULTIPLE` error occurs. This is explained in the [`curandGenerateNormal` documentation](https://docs.nvidia.com/cuda/curand/group__HOST.html#group__HOST_1gb9280e447ef04e1dec4611720bd0eb69):
    > Normally distributed results are generated from pseudorandom generators with a Box-Muller transform, and so require `n` to be even.

    The new warning (example below) is raised if the grid is odd, when the random thermal field is updated for the first time.
    ```
    // WARNING: nonzero temperature requires an even amount of grid cells,
    //          but all axes have an odd number of cells: [625 625 1].
    //          This may cause a CURAND_STATUS_LENGTH_NOT_MULTIPLE error.
    ```

These warnings are printed during program execution, so may be buried within the output. Alternatively, an error could be raised, but that seems premature if the CUDA error has not yet occurred. Alternatively, the warning could be printed at the very end of the output, but that seems hard to implement.