### PR TITLE
Add CPU info on Windows

### DIFF
--- a/cmd/mumax3/main.go
+++ b/cmd/mumax3/main.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/sys/windows/registry"
+
 	"github.com/mumax/3/cuda"
 	"github.com/mumax/3/engine"
 	"github.com/mumax/3/script"
@@ -171,7 +173,7 @@ func printVersion() {
 	engine.LogOut(fmt.Sprintf("commit hash: %s", commitHash))
 	engine.LogOut(getCPUInfo())
 	engine.LogOut(fmt.Sprintf("GPU info: %s, using cc=%d PTX", cuda.GPUInfo, cuda.UseCC))
-	osInfo := fmt.Sprintf("OS info: %s, Hostname: %s", getOSInfo(), getHostname())
+	osInfo := fmt.Sprintf("OS  info: %s, Hostname: %s", getOSInfo(), getHostname())
 	engine.LogOut(osInfo)
 	engine.LogOut(fmt.Sprintf("Timestamp: %s", time.Now().Format("2006-01-02 15:04:05")))
 	engine.LogOut("(c) Arne Vansteenkiste, Dynamat LAB, Ghent University, Belgium")
@@ -232,41 +234,65 @@ func getCPUInfo() string {
 	// Check the runtime operating system
 	switch runtime.GOOS {
 	case "windows":
-		return "CPU info: Windows OS"
+		return getWindowsCPUInfo()
 	case "linux":
-		file, err := os.Open("/proc/cpuinfo")
-		if err != nil {
-			return fmt.Sprintf("CPU info: Unknown, Error: %s", err.Error())
-		}
-		defer file.Close()
-
-		scanner := bufio.NewScanner(file)
-		var cpuDetails []string
-		var cpuModel, cpuCores, cpuMHz string
-		for scanner.Scan() {
-			line := scanner.Text()
-			fields := strings.Split(line, ":")
-			if len(fields) != 2 {
-				continue
-			}
-			key := strings.TrimSpace(fields[0])
-			value := strings.TrimSpace(fields[1])
-			switch key {
-			case "model name":
-				cpuModel = value
-			case "cpu cores":
-				cpuCores = value
-			case "cpu MHz":
-				cpuMHz = value
-			}
-		}
-		if cpuModel != "" && cpuCores != "" && cpuMHz != "" {
-			cpuDetails = append(cpuDetails, fmt.Sprintf("CPU info: %s, Cores: %s, MHz: %s", cpuModel, cpuCores, cpuMHz))
-		}
-
-		return strings.Join(cpuDetails, "; ")
+		return getLinuxCPUInfo()
 	// Add more cases for other operating systems if needed
 	default:
 		return fmt.Sprintf("CPU info: Unknown OS: %s", runtime.GOOS)
 	}
+}
+
+func getWindowsCPUInfo() string {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, `HARDWARE\DESCRIPTION\System\CentralProcessor\0`, registry.QUERY_VALUE)
+	if err != nil {
+		return fmt.Sprintf("CPU info: Unknown, Error: %s", err.Error())
+	}
+	defer key.Close()
+
+	cpuModel, _, err := key.GetStringValue("ProcessorNameString")
+	if err != nil {
+		cpuModel = "Unknown model"
+	}
+	cpuCores := runtime.NumCPU()
+	cpuMHz, _, err := key.GetIntegerValue("~MHz")
+	if err != nil {
+		cpuMHz = 0
+	}
+
+	return fmt.Sprintf("CPU info: %s, Cores: %d, MHz: %d", cpuModel, cpuCores, cpuMHz)
+}
+
+func getLinuxCPUInfo() string {
+	file, err := os.Open("/proc/cpuinfo")
+	if err != nil {
+		return fmt.Sprintf("CPU info: Unknown, Error: %s", err.Error())
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	var cpuDetails []string
+	var cpuModel, cpuCores, cpuMHz string
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Split(line, ":")
+		if len(fields) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(fields[0])
+		value := strings.TrimSpace(fields[1])
+		switch key {
+		case "model name":
+			cpuModel = value
+		case "cpu cores":
+			cpuCores = value
+		case "cpu MHz":
+			cpuMHz = value
+		}
+	}
+	if cpuModel != "" && cpuCores != "" && cpuMHz != "" {
+		cpuDetails = append(cpuDetails, fmt.Sprintf("CPU info: %s, Cores: %s, MHz: %s", cpuModel, cpuCores, cpuMHz))
+	}
+
+	return strings.Join(cpuDetails, "; ")
 }

--- a/cmd/mumax3/main.go
+++ b/cmd/mumax3/main.go
@@ -45,7 +45,6 @@ func main() {
 	// used by bootstrap launcher to test cuda
 	// successful exit means cuda was initialized fine
 	if *flag_test {
-		fmt.Println(cuda.GPUInfo)
 		os.Exit(0)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/mumax/3
 
 go 1.22.4
+
+require golang.org/x/sys v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
+golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
The previous `feature_log` branch (merged in commit e07e134bd00192201d4bf642ba5658d3c380e2eb) only retrieved CPU info for Linux.

This PR adds CPU info for Windows systems. This does, however, require [an external dependency](https://pkg.go.dev/golang.org/x/sys@v0.26.0/windows/registry) to get keys from the Windows Registry. I am not sure if this is desirable, so I leave this as a Pull Request for now. Thoughts @JLeliaert?

Also, the command `mumax3 -test` previously printed the GPU info, but since the new log prints the GPU info regardless, I have removed this now superfluous print statement from `mumax3 -test`.