### PR TITLE
RunningAverage

### DIFF
--- a/doc/templates/api-template.html
+++ b/doc/templates/api-template.html
@@ -561,7 +561,7 @@ saveas(chargeDensity, "chargeDensity.ovf")
 
 	<hr/>
 
-	{{range .FilterName "Add" "Const" "ConstVector" "Cross" "Div" "Dot" "MAdd" "Masked" "Mul" "MulMV" "Shifted"}} {{template "entry" .}} {{end}}
+	{{range .FilterName "Add" "Const" "ConstVector" "Cross" "Div" "Dot" "MAdd" "Masked" "Mul" "MulMV" "Shifted" "RunningAverage" "RunningSum"}} {{template "entry" .}} {{end}}
 
 </div>
 

--- a/doc/templates/api-template.html
+++ b/doc/templates/api-template.html
@@ -561,7 +561,7 @@ saveas(chargeDensity, "chargeDensity.ovf")
 
 	<hr/>
 
-	{{range .FilterName "Add" "Const" "ConstVector" "Cross" "Div" "Dot" "MAdd" "Masked" "Mul" "MulMV" "Shifted" "RunningAverage" "RunningSum"}} {{template "entry" .}} {{end}}
+	{{range .FilterName "Add" "Const" "ConstVector" "Cross" "Div" "Dot" "MAdd" "Masked" "Mul" "MulMV" "Shifted" "RunningAverage" "RunningSum" "Sum" "SumVector"}} {{template "entry" .}} {{end}}
 
 </div>
 

--- a/doc/templates/api-template.html
+++ b/doc/templates/api-template.html
@@ -561,7 +561,7 @@ saveas(chargeDensity, "chargeDensity.ovf")
 
 	<hr/>
 
-	{{range .FilterName "Add" "Const" "ConstVector" "Cross" "Div" "Dot" "MAdd" "Masked" "Mul" "MulMV" "Shifted" "RunningAverage" "RunningSum" "Sum" "SumVector"}} {{template "entry" .}} {{end}}
+	{{range .FilterName "Add" "Const" "ConstVector" "Cross" "Div" "Dot" "MAdd" "Masked" "Mul" "MulMV" "Shifted" "RunningAverage" "Sum" "SumVector"}} {{template "entry" .}} {{end}}
 
 </div>
 

--- a/engine/customfield.go
+++ b/engine/customfield.go
@@ -76,7 +76,7 @@ func AddCustomField(dst *data.Slice) {
 	}
 }
 
-// Adds the custom energy densities (defined with AddCustomE
+// Adds the custom energy densities (defined with AddEdensTerm)
 func AddCustomEnergyDensity(dst *data.Slice) {
 	for _, term := range customEnergies {
 		buf := ValueOf(term)
@@ -118,7 +118,7 @@ func ConstVector(x, y, z float64) Quantity {
 }
 
 // fieldOp holds the abstract functionality for operations
-// (like add, multiply, ...) on space-dependend quantites
+// (like add, multiply, ...) on space-dependent quantites
 // (like M, B_sat, ...)
 type fieldOp struct {
 	a, b  Quantity
@@ -394,7 +394,7 @@ func (q *shifted) NComp() int {
 }
 
 // Masks a quantity with a shape
-// The shape will be only evaluated once on the mesh,
+// The shape will only be evaluated once on the mesh,
 // and will be re-evaluated after mesh change,
 // because otherwise too slow
 func Masked(q Quantity, shape Shape) Quantity {

--- a/test/runningaverage.mx3
+++ b/test/runningaverage.mx3
@@ -1,0 +1,75 @@
+/*
+	Test RunningAverage() and RunningSum() of a (custom) Quantity (implemented in
+    engine/customfield.go), by doing the same physical test as in thermometer.go.
+
+    ================
+
+    Checks if the measured temperature in a ferromagnetic PMA film is equal to the input temperature.
+    We measure the temperature with the thermometer derived in PHYSICAL REVIEW E 82, 031111 (2010):
+
+        T = (Vcell*Msat)/(2*kB) * <Σ||m x h||^2> / <Σ m.h >     [1]
+
+    The expectation values <...> are calculated by taking time averages.
+    The sums Σ... are taken over the different cells.
+
+    The input temperature is chosen to be 177K.
+    We allow an error smaller than 5K.
+
+    NOTE:
+
+    The exchange energy in MuMax3 is shifted by a constant with respect to atomistic simulations.
+    Due to this difference, we need to add the following constant value to the divisor of [1]:
+
+        shift = 2 * (Aex/Msat) * NCell * ( 2/Δx² + 2/Δy² )
+
+*/
+
+//// Create system
+c := 4e-9
+Nxy := 128
+SetGridSize(Nxy, Nxy, 1)
+SetCellSize(c, c, c)
+SetPBC(1, 1, 0)
+
+//// Set material parameters and initial state
+Msat = 580e3
+Aex = 15e-12
+AnisU = Vector(0, 0, 1)
+Ku1 = 0.6e6
+Alpha = 0.1
+Temp = 177
+M = Uniform(0, 0, -1)
+Run(1e-10)
+
+//// Create average/sum trackers
+h := Add(Add(B_demag, B_exch), B_anis)
+mxh := Cross(m, h)
+dmh := Dot(m, h)
+dmxh := Dot(mxh, mxh)
+divisor := RunningAverage(dmh)
+divisor_sum := RunningSum(dmh)
+numerator := RunningAverage(dmxh)
+numerator_sum := RunningSum(dmxh)
+
+//// Run while tracking average/sum
+Nsteps := step
+Run(1e-10)
+Nsteps = step - Nsteps
+
+//// Check results
+// Temperature as expected? (using RunningAverage)
+Vcell := c * c * c
+kB := 1.38064852e-23 // Boltzmann constant
+N := Nxy * Nxy
+offset := 2 * Aex.GetRegion(0) / Msat.Average() * N * (2/(c*c) + 2/(c*c))
+temperature := (Vcell * Msat.Average() / (2 * kB)) * Sum(numerator) / (Sum(divisor) + offset)
+Expect("temperature", temperature, Temp.GetRegion(0), 5)
+
+// Temperature as expected? (using RunningSum/Nsteps)
+numerator_sum_avg := Sum(numerator_sum) / Nsteps
+divisor_sum_avg := Sum(divisor_sum) / Nsteps
+temperature_sum := (Vcell * Msat.Average() / (2 * kB)) * numerator_sum_avg / (divisor_sum_avg + offset)
+Expect("temperature_sum", temperature_sum, Temp.GetRegion(0), 5)
+
+// Temperatures similar?
+Expect("temperatures", temperature, temperature_sum, 1e-2) // Only up to 1e-2 because they use different averaging method

--- a/test/runningaverage.mx3
+++ b/test/runningaverage.mx3
@@ -1,6 +1,6 @@
 /*
-	Test RunningAverage() and RunningSum() of a (custom) Quantity (implemented in
-    engine/customfield.go), by doing the same physical test as in thermometer.go.
+	Test RunningAverage() of a (custom) Quantity (implemented in engine/customfield.go),
+    by performing the same physical test as in thermometer.go
 
     ================
 
@@ -41,35 +41,19 @@ Temp = 177
 M = Uniform(0, 0, -1)
 Run(1e-10)
 
-//// Create average/sum trackers
+//// Track average over 0.1ns
 h := Add(Add(B_demag, B_exch), B_anis)
 mxh := Cross(m, h)
 dmh := Dot(m, h)
 dmxh := Dot(mxh, mxh)
 divisor := RunningAverage(dmh)
-divisor_sum := RunningSum(dmh)
 numerator := RunningAverage(dmxh)
-numerator_sum := RunningSum(dmxh)
-
-//// Run while tracking average/sum
-Nsteps := step
 Run(1e-10)
-Nsteps = step - Nsteps
 
-//// Check results
-// Temperature as expected? (using RunningAverage)
+//// Check results: is temperature as expected?
 Vcell := c * c * c
 kB := 1.38064852e-23 // Boltzmann constant
 N := Nxy * Nxy
 offset := 2 * Aex.GetRegion(0) / Msat.Average() * N * (2/(c*c) + 2/(c*c))
 temperature := (Vcell * Msat.Average() / (2 * kB)) * Sum(numerator) / (Sum(divisor) + offset)
 Expect("temperature", temperature, Temp.GetRegion(0), 5)
-
-// Temperature as expected? (using RunningSum/Nsteps)
-numerator_sum_avg := Sum(numerator_sum) / Nsteps
-divisor_sum_avg := Sum(divisor_sum) / Nsteps
-temperature_sum := (Vcell * Msat.Average() / (2 * kB)) * numerator_sum_avg / (divisor_sum_avg + offset)
-Expect("temperature_sum", temperature_sum, Temp.GetRegion(0), 5)
-
-// Temperatures similar?
-Expect("temperatures", temperature, temperature_sum, 1e-2) // Only up to 1e-2 because they use different averaging method


### PR DESCRIPTION
This PR adds 3 new functions for manipulating (custom) `Quantity`s:

- `RunningAverage()`: tracks the running average over time of a given `Quantity` (for each cell individually, so this function also returns a full `Quantity`). The averaging takes the time step into account: when advancing a time step $$dt$$, the average will be updated based on the previous average $$a(t)$$ and the value $$q(t+dt)$$ of the quantity after the step :

  $$a(t+dt) = \frac{t \cdot a(t) + dt \cdot q(t+dt)}{t+dt}$$

- `Sum()` and `SumVector()`: the total of the `Quantity`, summed over all cells in the simulation grid.
  -  `Sum()` returns a scalar `float64` and can be used for both scalar and vector quantities. For a vector quantity, all components will be added together.
  - `SumVector()` returns a `data.Vector` and can only be used for vector quantities.