### PR TITLE
Feature/Extend ext_bubblepos to also work when a geometry is defined

### DIFF
--- a/engine/geom.go
+++ b/engine/geom.go
@@ -292,7 +292,7 @@ func (g *geom) shift(dx int) {
 	data.Copy(s, s2)
 
 	n := Mesh().Size()
-	x1, x2 := shiftDirtyRange(dx)
+	x1, x2 := shiftDirtyRange(dx, X)
 
 	for iz := 0; iz < n[Z]; iz++ {
 		for iy := 0; iy < n[Y]; iy++ {
@@ -322,7 +322,7 @@ func (g *geom) shiftY(dy int) {
 	data.Copy(s, s2)
 
 	n := Mesh().Size()
-	y1, y2 := shiftDirtyRange(dy)
+	y1, y2 := shiftDirtyRange(dy, Y)
 
 	for iz := 0; iz < n[Z]; iz++ {
 		for ix := 0; ix < n[X]; ix++ {
@@ -337,16 +337,16 @@ func (g *geom) shiftY(dy int) {
 
 }
 
-// x range that needs to be refreshed after shift over dx
-func shiftDirtyRange(dx int) (x1, x2 int) {
-	nx := Mesh().Size()[X]
-	util.Argument(dx != 0)
-	if dx < 0 {
-		x1 = nx + dx
-		x2 = nx
+// range along component that needs to be refreshed after shift over d
+func shiftDirtyRange(d, comp int) (p1, p2 int) {
+	n := Mesh().Size()[comp]
+	util.Argument(d != 0)
+	if d < 0 {
+		p1 = n + d
+		p2 = n
 	} else {
-		x1 = 0
-		x2 = dx
+		p1 = 0
+		p2 = d
 	}
 	return
 }

--- a/engine/regions.go
+++ b/engine/regions.go
@@ -270,7 +270,7 @@ func (b *Regions) shift(dx int) {
 	r1.Copy(r2)
 
 	n := Mesh().Size()
-	x1, x2 := shiftDirtyRange(dx)
+	x1, x2 := shiftDirtyRange(dx, X)
 
 	for iz := 0; iz < n[Z]; iz++ {
 		for iy := 0; iy < n[Y]; iy++ {
@@ -295,7 +295,7 @@ func (b *Regions) shiftY(dy int) {
 	r1.Copy(r2)
 
 	n := Mesh().Size()
-	y1, y2 := shiftDirtyRange(dy)
+	y1, y2 := shiftDirtyRange(dy, Y)
 
 	for iz := 0; iz < n[Z]; iz++ {
 		for ix := 0; ix < n[X]; ix++ {

--- a/test/bubblepos.mx3
+++ b/test/bubblepos.mx3
@@ -21,8 +21,19 @@ ext_backgroundtilt=0.25 //default value
 TOL:=1e-9
 expectv("position", ext_bubblepos.average(), vector(-3e-08,0,0), TOL)
 
+// add non-trivial geometry
+SetGeom(Square(30e-9).transl(30e-9,0e-9,0).inverse())
+// no minimization to save time
+expectv("position", ext_bubblepos.average(), vector(-3e-08,0,0), TOL)
+SetGeom(Universe())  // reset to trivial
+
 
 SetMesh(128, 128, 1, 1e-9,1e-9,0.4e-9, 0, 1, 0)
 m =neelskyrmion(1, -1).transl(0e-9,-30e-9,0)
 minimize()
+expectv("position", ext_bubblepos.average(), vector(0,-3e-08,0), TOL)
+
+// add non-trivial geometry
+SetGeom(Square(30e-9).transl(0e-9,30e-9,0).inverse())
+// no minimization to save time
 expectv("position", ext_bubblepos.average(), vector(0,-3e-08,0), TOL)


### PR DESCRIPTION
When the geometry is defined, load it into an array usable on CPU and multiply it with the magnetization to be used as weight:
- 0 weight outside geometry
- 100% weight inside geometry as normal
- partial weight for partial geometry

I hope this GPU-CPU copying is done cleanly. Maybe someone with more experience can chime in, but it works.

I also optimized the code a bit while I was at it:
- less for loops
- less recalculating the same values
- less divisions.

Need to make a new test script before merging though. :heavy_check_mark: added in 3918beb.