### PR TITLE
Fix DMI Neumann boundary conditions for non-3D simulations

### DIFF
--- a/cuda/dmibulk.cu
+++ b/cuda/dmibulk.cu
@@ -146,8 +146,8 @@ adddmibulk(float* __restrict__ Hx, float* __restrict__ Hy, float* __restrict__ H
         }
     }
 
-    // only take vertical derivative for 3D sim
-    if (Nz != 1) {
+    // only take vertical derivative for 3D sim or for Neumann BC
+    if ((Nz != 1) || (!OpenBC)) {
         // bottom neighbor
         {
             float3 m1 = make_float3(0.0f, 0.0f, 0.0f);

--- a/test/dmibulksymm1D.mx3
+++ b/test/dmibulksymm1D.mx3
@@ -1,7 +1,7 @@
 /*
-	Symmetry test for bulk DMI in a 1D magnet with Neumann BC.
-	Rotating the entire system by 90° should give symmetric result.
-    This test is based on the proposed 1D standard problem of bulk BMI:
+    Symmetry test for bulk DMI in a 1D magnet with Neumann BC.
+    Rotating the entire system by 90° should give symmetric result.
+    This test is based on the proposed 1D standard problem of bulk DMI:
     https://doi.org/10.1088/1367-2630/aaea1c
 */
 

--- a/test/dmibulksymm1D.mx3
+++ b/test/dmibulksymm1D.mx3
@@ -1,0 +1,43 @@
+/*
+	Symmetry test for bulk DMI in a 1D magnet with Neumann BC.
+	Rotating the entire system by 90° should give symmetric result.
+    This test is based on the proposed 1D standard problem of bulk BMI:
+    https://doi.org/10.1088/1367-2630/aaea1c
+*/
+
+N := 100
+c := 1e-9
+TOL := 1e-7
+
+setcellsize(c, c, c)
+setgridsize(N, 1, 1)
+
+msat = 0.86e6
+aex = 13e-12
+Ku1 = 0.4e6
+Dbulk = 3e-3
+enabledemag = False
+openBC = False
+
+// x-direction
+anisU = vector(0, 0, 1)
+m = Uniform(0, 0, 1)
+minimize()
+print("Magnet along X:", m)
+m0 := m.Average()
+
+// y-direction
+setgridsize(1, N, 1)
+anisU = vector(1, 0, 0)
+m = Uniform(1, 0, 0)
+minimize()
+print("Magnet along Y:", m)
+expect("alongY", m.Average().X(), m0.Z(), TOL)
+
+// z-direction
+setgridsize(1, 1, N)
+anisU = vector(0, 1, 0)
+m = Uniform(0, 1, 0)
+minimize()
+print("Magnet along Z:", m)
+expect("alongZ", m.Average().Y(), m0.Z(), TOL)


### PR DESCRIPTION
This should fix issue #352. Calculation of the effective magnetic field of bulk DMI was skipped when there was no derivative to be taken in the z-direction, but the Neumann boundary conditions do not cancel out. Open BC can still be skipped, and for interfacial DMI this is not a problem.
I also added a test to confirm the expected symmetry.