### PR TITLE
Feature/Add Triangle Shape

### DIFF
--- a/engine/shape.go
+++ b/engine/shape.go
@@ -20,6 +20,7 @@ func init() {
 	DeclFunc("Cuboid", Cuboid, "Cuboid with sides in meter")
 	DeclFunc("Rect", Rect, "2D rectangle with size in meter")
 	DeclFunc("Square", Square, "2D square with size in meter")
+	DeclFunc("Triangle", Triangle, "2D triangle with vertices (x0, y0), (x1, y1) and (x2, y2)")
 	DeclFunc("XRange", XRange, "Part of space between x1 (inclusive) and x2 (exclusive), in meter")
 	DeclFunc("YRange", YRange, "Part of space between y1 (inclusive) and y2 (exclusive), in meter")
 	DeclFunc("ZRange", ZRange, "Part of space between z1 (inclusive) and z2 (exclusive), in meter")
@@ -85,6 +86,26 @@ func Rect(sidex, sidey float64) Shape {
 // 2D square with given side.
 func Square(side float64) Shape {
 	return Rect(side, side)
+}
+
+// 2D triangle with given vertices.
+func Triangle(x0, y0, x1, y1, x2, y2 float64) Shape {
+	Sc := y0*x2 - x0*y2
+	Sx := y2 - y0
+	Sy := x0 - x2
+
+	Tc := x0*y1 - y0*x1
+	Tx := y0 - y1
+	Ty := x1 - x0
+
+	A2m1 := 1 / (-y1*x2 + y0*(-x1+x2) + x0*(y1-y2) + x1*y2) // 1 / (2 * area)
+
+	return func(x, y, z float64) bool {
+		// barycentric coordinates
+		s := A2m1 * (Sc + Sx*x + Sy*y)
+		t := A2m1 * (Tc + Tx*x + Ty*y)
+		return ((0 <= s) && (0 <= t) && (s+t <= 1))
+	}
 }
 
 // All cells with x-coordinate between a and b


### PR DESCRIPTION
Adds triangle Shape, which asks for 6 float64 numbers, which represent the 3 2D vertices (x0, y0), (x1, y1) and (x2, y2). Using barycentric coordinates, the Shape returns true if the given (x, y, z) coordinate is inside of the triangle, regardless of the levorotation.

This will divide by 0 if the triangle has no area, but why would you define such a triangle.