### PR TITLE
Fix #267: -gpu flag ignored when running multiple input scripts

### DIFF
--- a/cmd/mumax3/queue.go
+++ b/cmd/mumax3/queue.go
@@ -81,8 +81,7 @@ func (s *stateTab) Finish(j job) {
 
 // Runs all the jobs in stateTab.
 func (s *stateTab) Run() {
-	nGPU := cu.DeviceGetCount()
-	idle := initGPUs(nGPU)
+	idle, nGPU := initGPUs()
 	for {
 		gpu := <-idle
 		addr := fmt.Sprint(":", 35368+gpu)
@@ -138,16 +137,27 @@ func run(inFile string, gpu int, webAddr string) {
 	}
 }
 
-func initGPUs(nGpu int) chan int {
+// Creates a concurrent channel containing the available GPU IDs for jobs.
+// Returns the channel and the number of available GPUs for the queue.
+func initGPUs() (chan int, int) {
+	nGpu := cu.DeviceGetCount()
 	if nGpu == 0 {
 		log.Fatal("no GPUs available")
-		panic(0)
+	}
+
+	singleGPU := engine.FlagPassed("gpu")
+	if singleGPU {
+		nGpu = 1
 	}
 	idle := make(chan int, nGpu)
-	for i := 0; i < nGpu; i++ {
-		idle <- i
+	if singleGPU {
+		idle <- *engine.Flag_gpu
+	} else {
+		for i := 0; i < nGpu; i++ {
+			idle <- i
+		}
 	}
-	return idle
+	return idle, nGpu
 }
 
 func (s *stateTab) PrintTo(w io.Writer) {

--- a/cmd/mumax3/queue.go
+++ b/cmd/mumax3/queue.go
@@ -26,6 +26,7 @@ func RunQueue(files []string) {
 	s := NewStateTab(files)
 	s.PrintTo(os.Stdout)
 	go s.ListenAndServe(*engine.Flag_port)
+	fmt.Print("//Realtime queue overview available at http://127.0.0.1", *engine.Flag_port, "\n")
 	s.Run()
 	fmt.Println(numOK.get(), "OK, ", numFailed.get(), "failed")
 	os.Exit(int(exitStatus))

--- a/engine/gofiles.go
+++ b/engine/gofiles.go
@@ -4,10 +4,11 @@ package engine
 
 import (
 	"flag"
-	"github.com/mumax/3/cuda"
-	"github.com/mumax/3/util"
 	"os"
 	"path"
+
+	"github.com/mumax/3/cuda"
+	"github.com/mumax/3/util"
 )
 
 var (
@@ -22,6 +23,16 @@ var (
 	Flag_sync        = flag.Bool("sync", false, "Synchronize all CUDA calls (debug)")
 	Flag_forceclean  = flag.Bool("f", false, "Force start, clean existing output directory")
 )
+
+func FlagPassed(name string) bool {
+	passed := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			passed = true
+		}
+	})
+	return passed
+}
 
 // Usage: in every Go input file, write:
 //

--- a/engine/gofiles.go
+++ b/engine/gofiles.go
@@ -14,7 +14,7 @@ import (
 var (
 	// These flags are shared between cmd/mumax3 and Go input files.
 	Flag_cachedir    = flag.String("cache", os.TempDir(), "Kernel cache directory (empty disables caching)")
-	Flag_gpu         = flag.Int("gpu", 0, "Specify GPU")
+	Flag_gpu         = flag.Int("gpu", 0, "Specify a single GPU (use CUDA_AVAILABLE_DEVICES environment variable for advanced selection)")
 	Flag_interactive = flag.Bool("i", false, "Open interactive browser session")
 	Flag_od          = flag.String("o", "", "Override output directory")
 	Flag_port        = flag.String("http", ":35367", "Port to serve web gui")


### PR DESCRIPTION
As reported in #267, running a command like `mumax3 -gpu=0 script1.mx3 script2.mx3` on a system with multiple GPUs would run both scripts in parallel, each on a different GPU, despite the `-gpu=0` flag.

This PR fixes this unintuitive behaviour of the `-gpu` flag. The aforementioned command will now run both scripts sequentially on GPU 0.