### PR TITLE
Fix #376: ExchCoupling and DindCoupling are factor 4 or 6 too large

### DIFF
--- a/cuda/exchange.go
+++ b/cuda/exchange.go
@@ -28,7 +28,7 @@ func AddExchange(B, m *data.Slice, Aex SymmLUT, Msat MSlice, regions *Bytes, mes
 		wx, wy, wz, N[X], N[Y], N[Z], pbc, cfg)
 }
 
-// Finds the average exchange strength around each cell, for debugging.
+// Finds the average exchange strength around each cell, as used by ExchCoupling and DindCoupling.
 func ExchangeDecode(dst *data.Slice, Aex SymmLUT, regions *Bytes, mesh *data.Mesh) {
 	c := mesh.CellSize()
 	wx := float32(2 / (c[X] * c[X]))

--- a/cuda/exchangedecode.cu
+++ b/cuda/exchangedecode.cu
@@ -48,6 +48,10 @@ exchangedecode(float* __restrict__ dst, float* __restrict__ aLUT2d, uint8_t* __r
         // top neighbor
         i_  = idx(ix, iy, hclampz(iz+1));
         avg += aLUT2d[symidx(r0, regions[i_])];
+        
+        avg /= 6;
+    } else {
+        avg /= 4;
     }
 
     dst[I] = avg;

--- a/test/dindcoupling.mx3
+++ b/test/dindcoupling.mx3
@@ -24,6 +24,6 @@ scale := 0.645
 ext_ScaleDind(0,1,scale)
 
 avgdmi := dindCoupling.average()
-wanted := 4*D0 + 2*(scale-1)*D0*ni/(nx*nx)
+wanted := (4*D0 + 2*(scale-1)*D0*ni/(nx*nx))/4
 
 expect("dmicoupling",avgdmi,wanted,1e-2)

--- a/test/exchcoupling.mx3
+++ b/test/exchcoupling.mx3
@@ -42,4 +42,4 @@ for i:=0; i<maxRegion; i++{
 
 m = vortex(1, 1)
 
-expect("exchangecoupling", exchCoupling.Average()/Msat.Average(), 59.83329e-18, 0.001) // golden value mumax3.9.1 2015/12/11
+expect("exchangecoupling", exchCoupling.Average()/Msat.Average(), 59.83329e-18, 0.001e-18) // golden value mumax3.9.1 2015/12/11

--- a/test/exchcoupling.mx3
+++ b/test/exchcoupling.mx3
@@ -42,4 +42,4 @@ for i:=0; i<maxRegion; i++{
 
 m = vortex(1, 1)
 
-expect("exchangecoupling", exchCoupling.Average()/Msat.Average(), 59.83329e-18, 0.001e-18) // golden value mumax3.9.1 2015/12/11
+expect("exchangecoupling", exchCoupling.Average()/Msat.Average(), 59.83329e-18/4, 0.001e-18) // golden value mumax3.9.1 2015/12/11, divided by 4 following issue #376


### PR DESCRIPTION
This PR fixes #376, where it was noted that the `cuda.exchangeDecode()` function only summed over neighbouring cells, rather than averaging over them.

> [!NOTE]  
> This affects the input script variables `ExchCoupling` and `DindCoupling`, whose values are now 4 or 6 times smaller.