### PR TITLE
Bugfix/flag_http

### DIFF
--- a/cmd/mumax3/queue.go
+++ b/cmd/mumax3/queue.go
@@ -7,14 +7,17 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
+	"strconv"
 	"sync"
 	"sync/atomic"
 
 	"github.com/mumax/3/cuda/cu"
 	"github.com/mumax/3/engine"
+	"github.com/mumax/3/util"
 )
 
 var (
@@ -87,7 +90,8 @@ func (s *stateTab) Run() {
 		gpu := <-idle
 		addr := ""
 		if *engine.Flag_port != "" {
-			addr = fmt.Sprint(":", 35368+gpu)
+			_, p, _ := net.SplitHostPort(*engine.Flag_port)
+			addr = fmt.Sprint(":", atoi(p)+1+gpu) // +1 because Flag_port hosts overview of queue
 		}
 		j, ok := s.StartNext(addr)
 		if !ok {
@@ -103,6 +107,12 @@ func (s *stateTab) Run() {
 	for i := 1; i < nGPU; i++ {
 		<-idle
 	}
+}
+
+func atoi(a string) int {
+	i, err := strconv.Atoi(a)
+	util.PanicErr(err)
+	return i
 }
 
 type atom int32

--- a/cmd/mumax3/queue.go
+++ b/cmd/mumax3/queue.go
@@ -85,7 +85,10 @@ func (s *stateTab) Run() {
 	idle, nGPU := initGPUs()
 	for {
 		gpu := <-idle
-		addr := fmt.Sprint(":", 35368+gpu)
+		addr := ""
+		if *engine.Flag_port != "" {
+			addr = fmt.Sprint(":", 35368+gpu)
+		}
 		j, ok := s.StartNext(addr)
 		if !ok {
 			break

--- a/engine/gofiles.go
+++ b/engine/gofiles.go
@@ -57,7 +57,9 @@ func InitAndClose() func() {
 	inFile := util.NoExt(od)
 	InitIO(inFile, od, *Flag_forceclean)
 
-	GoServe(*Flag_port)
+	if *Flag_port != "" {
+		GoServe(*Flag_port)
+	}
 
 	return func() {
 		Close()


### PR DESCRIPTION
When queuing multiple inputfiles (e.g., `mumax3 file1.mx3 file2.go file3.mx3`), the `-http` flag only controlled the port where the queue overview was served. The GUI of each script was hardcoded to always run on port `:35368` (and `:35369` and up on multi-gpu systems).

Hence, passing `-http=""` to avoid serving GUIs did not have the desired effect. For queued `.go` inputscripts, this was mildly annoying since (on some systems) each script individually requested passage through the firewall, despite passing `-http=""`.

**This PR changes this behaviour as follows:**
- **`-http=""`** $\rightarrow$ No attempt will be made to serve a GUI for any script in the queue.
- **`-http=":number"`** $\rightarrow$ The port `:number` will serve the queue overview, while `:number+1`, `:number+2`... serve the GUI of each GPU in the system (if those ports are available).