### PR TITLE
New shapes: Line and Line2D

### DIFF
--- a/engine/gui.go
+++ b/engine/gui.go
@@ -200,15 +200,19 @@ func (g *guistate) prepareGeom() {
 		}
 		args += ")"
 		// overwrite args for special cases
-		switch {
-		case ident == "Cell":
+		switch ident {
+		case "Cell":
 			args = "(0, 0, 0)"
-		case ident == "XRange" || ident == "YRange" || ident == "ZRange":
+		case "XRange", "YRange", "ZRange":
 			args = "(0, inf)"
-		case ident == "Layers":
+		case "Layers":
 			args = "(0, 1)"
-		case ident == "ImageShape":
+		case "ImageShape":
 			args = `("filename.png")`
+		case "Line":
+			args = `(-1, 0, 0, 1, 0, 0, 0, "infinite")`
+		case "Line2D":
+			args = `(-1, 0, 1, 0, 0, "infinite")`
 		}
 		g.Set("geomargs", args)
 		g.Set("geomdoc", g.Doc(ident))

--- a/engine/shape.go
+++ b/engine/shape.go
@@ -159,7 +159,7 @@ func Line2D(x1, y1, x2, y2, diam float64, linecap string) Shape {
 		return func(x, y, z float64) bool {
 			return diam*diam >= math.Pow((x-x1)*(y-y2)-(x-x2)*(y-y1), 2)/denom
 		}
-	case "round":
+	case "round", "flat":
 		return func(x, y, z float64) bool {
 			a, b := x2-x1, y2-y1
 			lenSq := a*a + b*b
@@ -167,6 +167,10 @@ func Line2D(x1, y1, x2, y2, diam float64, linecap string) Shape {
 			param := -1.0
 			if lenSq != 0 {
 				param = ((x-x1)*a + (y-y1)*b) / lenSq
+			}
+
+			if linecap == "flat" && (param < 0 || param > 1) { // If param is not in [0,1], then point is beyond line segment
+				return false
 			}
 
 			xx, yy := 0., 0.
@@ -202,7 +206,7 @@ func Line(x1, y1, z1, x2, y2, z2, diam float64, linecap string) Shape {
 			cross1, cross2, cross3 := dy1*dz2-dy2*dz1, dx1*dz2-dx2*dz1, dx1*dy2-dx2*dy1
 			return diam*diam >= (cross1*cross1+cross2*cross2+cross3*cross3)/denom
 		}
-	case "round":
+	case "round", "flat":
 		a, b, c := x2-x1, y2-y1, z2-z1
 		lenSq := a*a + b*b + c*c
 
@@ -210,6 +214,10 @@ func Line(x1, y1, z1, x2, y2, z2, diam float64, linecap string) Shape {
 			param := -1.0
 			if lenSq != 0 {
 				param = ((x-x1)*a + (y-y1)*b + (z-z1)*c) / lenSq
+			}
+
+			if linecap == "flat" && (param < 0 || param > 1) { // If param is not in [0,1], then point is beyond line segment
+				return false
 			}
 
 			xx, yy, zz := 0., 0., 0.

--- a/engine/shape.go
+++ b/engine/shape.go
@@ -239,7 +239,7 @@ func Line(x1, y1, z1, x2, y2, z2, diam float64, linecap string) Shape {
 }
 
 func LineIntersectsCell(p1, p2 [3]float64, Ndim int, linecap string) Shape {
-	eps := 1e-12
+	eps := 1e-6
 	return func(x, y, z float64) bool {
 		p := [3]float64{x, y, z}
 		tmin, tmax := math.Inf(-1), math.Inf(1)
@@ -248,7 +248,7 @@ func LineIntersectsCell(p1, p2 [3]float64, Ndim int, linecap string) Shape {
 			axmin, axmax := p[c]-cs/2, p[c]+cs/2
 			dax := p2[c] - p1[c]
 
-			if math.Abs(dax) < eps {
+			if math.Abs(dax) < eps*cs { // If along an axis: use faster check
 				if p1[c] < axmin || p1[c] > axmax {
 					return false
 				}

--- a/engine/shape.go
+++ b/engine/shape.go
@@ -13,9 +13,11 @@ import (
 
 func init() {
 	DeclFunc("Ellipsoid", Ellipsoid, "3D Ellipsoid with axes in meter")
-	DeclFunc("Superball", Superball, "3D Superball with diameter in meter and shape parameter p. Interpolates between a cube (p=+∞), sphere (p=1), octahedron (p=0.5) and empty space (p≤0).")
+	DeclFunc("Superball", Superball, "3D Superball with diameter in meter and shape parameter p."+
+		"<br>Interpolates between a cube (p=+∞), sphere (p=1), octahedron (p=0.5) and empty space (p≤0).")
 	DeclFunc("Ellipse", Ellipse, "2D Ellipse with axes in meter")
-	DeclFunc("Cone", Cone, "3D Cone with diameter and height in meter. The base is at z=0. If the height is positive, the tip points in the +z direction.")
+	DeclFunc("Cone", Cone, "3D Cone with diameter and height in meter. The base is at z=0."+
+		"<br>If the height is positive, the tip points in the +z direction.")
 	DeclFunc("Cylinder", Cylinder, "3D Cylinder with diameter and height in meter")
 	DeclFunc("Circle", Circle, "2D Circle with diameter in meter")
 	DeclFunc("Cuboid", Cuboid, "Cuboid with sides in meter")

--- a/engine/shape.go
+++ b/engine/shape.go
@@ -260,7 +260,7 @@ func LineIntersectsCell(p1, p2 [3]float64, Ndim int, linecap string) Shape {
 				}
 				tmin = math.Max(tmin, t1)
 				tmax = math.Min(tmax, t2)
-				if tmax < tmin {
+				if tmax < tmin-1e-15 {
 					return false
 				}
 			}

--- a/engine/shape.go
+++ b/engine/shape.go
@@ -25,8 +25,8 @@ func init() {
 	DeclFunc("Square", Square, "2D square with size in meter")
 	DeclFunc("Triangle", Triangle, "2D triangle with vertices (x0, y0), (x1, y1) and (x2, y2)")
 	DeclFunc("Line", Line, "3D line segment between (x1, y1, z1) and (x2, y2, z2), with given diameter, in meter."+
-		"<br>Last element specifies the line cap, which can be 'infinite' or 'round'."+
-		"<br>Using zero diameter creates a minimally connected geometry, unless it is scaled or rotated.")
+		"<br>Last element specifies the line cap, which can be 'infinite', 'round' or 'flat'."+
+		"<br>Using zero diameter creates a minimally connected geometry, unless it is later scaled/rotated.")
 	DeclFunc("Line2D", Line2D, "2D equivalent of Line(), resulting in a uniform fill along the z-axis")
 	DeclFunc("XRange", XRange, "Part of space between x1 (inclusive) and x2 (exclusive), in meter")
 	DeclFunc("YRange", YRange, "Part of space between y1 (inclusive) and y2 (exclusive), in meter")
@@ -147,6 +147,7 @@ func Triangle(x0, y0, x1, y1, x2, y2 float64) Shape {
 // Line capping modes are
 //   - "infinite": line extends indefinitely beyond the two specified points.
 //   - "round": the line segment ends in circles at the two specified points.
+//   - "flat": the line segment ends in a flat plane at the two specified points.
 func Line2D(x1, y1, x2, y2, diam float64, linecap string) Shape {
 	if diam == 0 { // Special case: shape consists of all cells that line intersects
 		return LineIntersectsCell([3]float64{x1, y1, 0}, [3]float64{x2, y2, 0}, 2, linecap)

--- a/engine/shape.go
+++ b/engine/shape.go
@@ -22,6 +22,10 @@ func init() {
 	DeclFunc("Rect", Rect, "2D rectangle with size in meter")
 	DeclFunc("Square", Square, "2D square with size in meter")
 	DeclFunc("Triangle", Triangle, "2D triangle with vertices (x0, y0), (x1, y1) and (x2, y2)")
+	DeclFunc("Line", Line, "3D line segment between (x1, y1, z1) and (x2, y2, z2), with given diameter, in meter."+
+		"<br>Last element specifies the line cap, which can be 'infinite' or 'round'."+
+		"<br>Using zero diameter creates a minimally connected geometry, unless it is scaled or rotated.")
+	DeclFunc("Line2D", Line2D, "2D equivalent of Line(), resulting in a uniform fill along the z-axis")
 	DeclFunc("XRange", XRange, "Part of space between x1 (inclusive) and x2 (exclusive), in meter")
 	DeclFunc("YRange", YRange, "Part of space between y1 (inclusive) and y2 (exclusive), in meter")
 	DeclFunc("ZRange", ZRange, "Part of space between z1 (inclusive) and z2 (exclusive), in meter")
@@ -134,6 +138,132 @@ func Triangle(x0, y0, x1, y1, x2, y2 float64) Shape {
 		s := Sc + Sx*x + Sy*y
 		t := Tc + Tx*x + Ty*y
 		return ((0 <= s) && (0 <= t) && (s+t <= 1))
+	}
+}
+
+// Line segment from (x1, y1) to (x2, y2).
+// Line capping modes are
+//   - "infinite": line extends indefinitely beyond the two specified points.
+//   - "round": the line segment ends in circles at the two specified points.
+func Line2D(x1, y1, x2, y2, diam float64, linecap string) Shape {
+	if diam == 0 { // Special case: shape consists of all cells that line intersects
+		return LineIntersectsCell([3]float64{x1, y1, 0}, [3]float64{x2, y2, 0}, 2, linecap)
+	}
+
+	switch linecap {
+	case "infinite":
+		dx, dy := x2-x1, y2-y1
+		denom := dx*dx + dy*dy
+		return func(x, y, z float64) bool {
+			return diam*diam >= math.Pow((x-x1)*(y-y2)-(x-x2)*(y-y1), 2)/denom
+		}
+	case "round":
+		return func(x, y, z float64) bool {
+			a, b := x2-x1, y2-y1
+			lenSq := a*a + b*b
+
+			param := -1.0
+			if lenSq != 0 {
+				param = ((x-x1)*a + (y-y1)*b) / lenSq
+			}
+
+			xx, yy := 0., 0.
+			if param < 0 {
+				xx, yy = x1, y1
+			} else if param > 1 {
+				xx, yy = x2, y2
+			} else {
+				xx, yy = x1+param*a, y1+param*b
+			}
+			dx, dy := x-xx, y-yy
+			return math.Sqrt(dx*dx+dy*dy) <= diam
+		}
+	default:
+		util.Fatal("Line capping method \"" + linecap + "\" is not implemented")
+		return nil
+	}
+}
+
+// Same as Line2D but in 3D
+func Line(x1, y1, z1, x2, y2, z2, diam float64, linecap string) Shape {
+	if diam == 0 { // Special case: shape consists of all cells that line intersects
+		return LineIntersectsCell([3]float64{x1, y1, z1}, [3]float64{x2, y2, z2}, 3, linecap)
+	}
+
+	switch linecap {
+	case "infinite":
+		dx, dy, dz := x2-x1, y2-y1, z2-z1
+		denom := dx*dx + dy*dy + dz*dz
+		return func(x, y, z float64) bool {
+			dx1, dy1, dz1 := x-x1, y-y1, z-z1
+			dx2, dy2, dz2 := x-x2, y-y2, z-z2
+			cross1, cross2, cross3 := dy1*dz2-dy2*dz1, dx1*dz2-dx2*dz1, dx1*dy2-dx2*dy1
+			return diam*diam >= (cross1*cross1+cross2*cross2+cross3*cross3)/denom
+		}
+	case "round":
+		a, b, c := x2-x1, y2-y1, z2-z1
+		lenSq := a*a + b*b + c*c
+
+		return func(x, y, z float64) bool {
+			param := -1.0
+			if lenSq != 0 {
+				param = ((x-x1)*a + (y-y1)*b + (z-z1)*c) / lenSq
+			}
+
+			xx, yy, zz := 0., 0., 0.
+			if param < 0 {
+				xx, yy, zz = x1, y1, z1
+			} else if param > 1 {
+				xx, yy, zz = x2, y2, z2
+			} else {
+				xx, yy, zz = x1+param*a, y1+param*b, z1+param*c
+			}
+			dx, dy, dz := x-xx, y-yy, z-zz
+			return math.Sqrt(dx*dx+dy*dy+dz*dz) <= diam
+		}
+	default:
+		util.Fatal("Line capping method \"" + linecap + "\" is not implemented")
+		return nil
+	}
+}
+
+func LineIntersectsCell(p1, p2 [3]float64, Ndim int, linecap string) Shape {
+	eps := 1e-12
+	return func(x, y, z float64) bool {
+		p := [3]float64{x, y, z}
+		tmin, tmax := math.Inf(-1), math.Inf(1)
+		for c := range Ndim { // Iterate over axes
+			cs := Mesh().CellSize()[c]
+			axmin, axmax := p[c]-cs/2, p[c]+cs/2
+			dax := p2[c] - p1[c]
+
+			if math.Abs(dax) < eps {
+				if p1[c] < axmin || p1[c] > axmax {
+					return false
+				}
+			} else {
+				t1 := (axmin - p1[c]) / dax
+				t2 := (axmax - p1[c]) / dax
+				if t1 > t2 {
+					t1, t2 = t2, t1
+				}
+				tmin = math.Max(tmin, t1)
+				tmax = math.Min(tmax, t2)
+				if tmax < tmin {
+					return false
+				}
+			}
+
+			switch linecap {
+			case "infinite":
+				continue
+			default: // Check if past line segment
+				if math.Max(p1[c], p2[c]) < axmin || math.Min(p1[c], p2[c]) > axmax {
+					return false
+				}
+			}
+		}
+		return true // If we survived all axes, then the t-intervals overlap, so an intersection exists.
 	}
 }
 

--- a/test/line.mx3
+++ b/test/line.mx3
@@ -39,6 +39,16 @@ for z := 0; z < 2*N2 + 1; z++ {
 	expect("geom", geom.GetCell(N2-23, N2-1, z), 0, 0) // Beyond line segment, but within "round"
 }
 
+shape = Line2D(-20*c, 0, 10*c, 5*c, 0, "infinite")
+SetGeom(shape)
+m = Uniform(1, 0, 0)
+SaveAs(m, "Line2D_infinite_d=0.ovf")
+for z := 0; z < 2*N2 + 1; z++ {
+	expect("geom", geom.GetCell(N2-5, N2+2, z), 1, 0) // Inside line segment
+	expect("geom", geom.GetCell(N2-5, N2+1, z), 0, 0) // Next to line segment
+	expect("geom", geom.GetCell(N2-26, N2-1, z), 1, 0) // Beyond line segment, but "infinite"
+}
+
 shape = Line(-20, 0, 0, 10, 5, 7, 4, "infinite").Scale(c, c, c)
 SetGeom(shape)
 m = Uniform(1, 0, 0)

--- a/test/line.mx3
+++ b/test/line.mx3
@@ -29,6 +29,16 @@ for z := 0; z < 2*N2 + 1; z++ {
 	expect("geom", geom.GetCell(N2-23, N2-1, z), 1, 0) // Beyond line segment, but within "round"
 }
 
+shape = Line2D(-20, 0, 10, 5, 4, "flat").Scale(c, c, c)
+SetGeom(shape)
+m = Uniform(1, 0, 0)
+SaveAs(m, "Line2D_flat.ovf")
+for z := 0; z < 2*N2 + 1; z++ {
+	expect("geom", geom.GetCell(N2-5, N2+3, z), 1, 0) // Inside line segment
+	expect("geom", geom.GetCell(N2-26, N2-1, z), 0, 0) // Beyond line segment
+	expect("geom", geom.GetCell(N2-23, N2-1, z), 0, 0) // Beyond line segment, but within "round"
+}
+
 shape = Line(-20, 0, 0, 10, 5, 7, 4, "infinite").Scale(c, c, c)
 SetGeom(shape)
 m = Uniform(1, 0, 0)
@@ -47,6 +57,22 @@ expect("geom", geom.GetCell(N2-19, N2+4, N2+0), 1, 0) // Just barely within "rou
 expect("geom", geom.GetCell(N2-19, N2-4, N2+0), 0, 0) // Just barely not within "round"
 expect("geom", geom.GetCell(N2-20, N2+0, N2+4), 1, 0) // Just barely within "round"
 expect("geom", geom.GetCell(N2-20, N2+0, N2+5), 0, 0) // Just barely not within "round"
+
+shape = Line(-20, 0, 0, 10, 5, 7, 4, "flat").Scale(c, c, c)
+SetGeom(shape)
+m = Uniform(1, 0, 0)
+SaveAs(m, "Line_flat.ovf")
+expect("geom", geom.GetCell(N2-20, N2+0, N2+0), 1, 0) // Inside line segment
+expect("geom", geom.GetCell(N2-20, N2+4, N2+0), 1, 0) // Just barely within segment
+expect("geom", geom.GetCell(N2-19, N2+4, N2+0), 1, 0) // Just barely within segment
+expect("geom", geom.GetCell(N2-19, N2-4, N2+0), 0, 0) // Just barely not within segment nor "round"
+expect("geom", geom.GetCell(N2-20, N2+0, N2+4), 1, 0) // On segment boundary
+expect("geom", geom.GetCell(N2-20, N2+0, N2+5), 0, 0) // Just barely outside segment boundary
+expect("geom", geom.GetCell(N2-21, N2+0, N2+4), 0, 0) // Just barely outside "round"
+expect("geom", geom.GetCell(N2-21, N2+0, N2+3), 0, 0) // Just barely within "round"
+expect("geom", geom.GetCell(N2-5, N2+3, N2+4), 1, 0) // Inside line segment
+expect("geom", geom.GetCell(N2-5, N2+3, N2+10), 0, 0) // Above line segment
+expect("geom", geom.GetCell(N2-26, N2-1, N2-2), 0, 0) // Beyond line segment, but in "infinite"
 
 shape = Line(-20*c, 0, 0, 10*c, 5*c, 7*c, 0, "infinite")
 SetGeom(shape)

--- a/test/line.mx3
+++ b/test/line.mx3
@@ -1,0 +1,73 @@
+/*
+	Test whether line (segments) are rendered as expected.
+	A select few cells are checked automatically, but we mostly save the geometry for visual inspection.
+*/
+
+N2 := 31
+c := 5e-9
+SetCellSize(c, c, c)
+SetGridSize(2*N2 + 1, 2*N2 + 1, 2*N2 + 1)
+Msat = 800e3
+Aex = 13e-12
+
+shape := Line2D(-20, 0, 10, 5, 4, "infinite").Scale(c, c, c)
+SetGeom(shape)
+m = Uniform(1, 0, 0)
+SaveAs(m, "Line2D_infinite.ovf")
+for z := 0; z < 2*N2 + 1; z++ {
+	expect("geom", geom.GetCell(N2-5, N2+3, z), 1, 0) // Inside line segment
+	expect("geom", geom.GetCell(N2-26, N2-1, z), 1, 0) // Beyond line segment, but "infinite"
+}
+
+shape = Line2D(-20, 0, 10, 5, 4, "round").Scale(c, c, c)
+SetGeom(shape)
+m = Uniform(1, 0, 0)
+SaveAs(m, "Line2D_round.ovf")
+for z := 0; z < 2*N2 + 1; z++ {
+	expect("geom", geom.GetCell(N2-5, N2+3, z), 1, 0) // Inside line segment
+	expect("geom", geom.GetCell(N2-26, N2-1, z), 0, 0) // Beyond line segment
+	expect("geom", geom.GetCell(N2-23, N2-1, z), 1, 0) // Beyond line segment, but within "round"
+}
+
+shape = Line(-20, 0, 0, 10, 5, 7, 4, "infinite").Scale(c, c, c)
+SetGeom(shape)
+m = Uniform(1, 0, 0)
+SaveAs(m, "Line_infinite.ovf")
+expect("geom", geom.GetCell(N2-5, N2+3, N2+4), 1, 0) // Inside line segment
+expect("geom", geom.GetCell(N2-5, N2+3, N2+10), 0, 0) // Above line segment
+expect("geom", geom.GetCell(N2-26, N2-1, N2-2), 1, 0) // Beyond line segment, but "infinite"
+
+shape = Line(-20, 0, 0, 10, 5, 7, 4, "round").Scale(c, c, c)
+SetGeom(shape)
+m = Uniform(1, 0, 0)
+SaveAs(m, "Line_round.ovf")
+expect("geom", geom.GetCell(N2-20, N2+0, N2+0), 1, 0) // Inside line segment
+expect("geom", geom.GetCell(N2-20, N2+4, N2+0), 1, 0) // Just barely within "round"
+expect("geom", geom.GetCell(N2-19, N2+4, N2+0), 1, 0) // Just barely within "round"
+expect("geom", geom.GetCell(N2-19, N2-4, N2+0), 0, 0) // Just barely not within "round"
+expect("geom", geom.GetCell(N2-20, N2+0, N2+4), 1, 0) // Just barely within "round"
+expect("geom", geom.GetCell(N2-20, N2+0, N2+5), 0, 0) // Just barely not within "round"
+
+shape = Line(-20*c, 0, 0, 10*c, 5*c, 7*c, 0, "infinite")
+SetGeom(shape)
+m = Uniform(1, 0, 0)
+SaveAs(m, "Line_infinite_d=0.ovf")
+expect("geom", geom.GetCell(N2-5, N2+2, N2+3), 1, 0) // Inside line segment
+expect("geom", geom.GetCell(N2-5, N2+1, N2+3), 0, 0) // Next to line segment
+expect("geom", geom.GetCell(N2-5, N2+3, N2+3), 0, 0) // Next to line segment
+expect("geom", geom.GetCell(N2-26, N2-1, N2-2), 1, 0) // Beyond line segment, but "infinite"
+
+shape = Line(-20*c, 0, 0, 10*c, 5*c, 7*c, 0, "round")
+SetGeom(shape)
+m = Uniform(1, 0, 0)
+SaveAs(m, "Line_round_d=0.ovf")
+expect("geom", geom.GetCell(N2-5, N2+2, N2+3), 1, 0) // Inside line segment
+expect("geom", geom.GetCell(N2-5, N2+1, N2+3), 0, 0) // Next to line segment
+expect("geom", geom.GetCell(N2-26, N2-1, N2-2), 0, 0) // Beyond line segment
+
+shape = Line(0, 0, 0, 0, 0, 10*c, 0, "round")
+SetGeom(shape)
+m = Uniform(1, 0, 0)
+SaveAs(m, "Line_round_d=0_axisAligned.ovf")
+expect("geom", geom.GetCell(N2+0, N2+0, N2+5), 1, 0) // Inside line segment
+expect("geom", geom.GetCell(N2+0, N2+1, N2+5), 0, 0) // Next to line segment

--- a/test/line.mx3
+++ b/test/line.mx3
@@ -92,7 +92,7 @@ m = Uniform(1, 0, 0)
 SaveAs(m, "Line_infinite_d=0.ovf")
 expect("geom", geom.GetCell(N2-5, N2+2, N2+3), 1, 0) // Inside line segment
 expect("geom", geom.GetCell(N2-5, N2+1, N2+3), 0, 0) // Next to line segment
-expect("geom", geom.GetCell(N2-5, N2+3, N2+3), 0, 0) // Next to line segment
+expect("geom", geom.GetCell(N2-5, N2+3, N2+3), 1, 0) // Next to line segment, but inside 1e-15 safety check
 expect("geom", geom.GetCell(N2-26, N2-1, N2-2), 1, 0) // Beyond line segment, but "infinite"
 
 shape = Line(-20*c, 0, 0, 10*c, 5*c, 7*c, 0, "round")

--- a/test/line.mx3
+++ b/test/line.mx3
@@ -52,11 +52,13 @@ SetGeom(shape)
 m = Uniform(1, 0, 0)
 SaveAs(m, "Line_round.ovf")
 expect("geom", geom.GetCell(N2-20, N2+0, N2+0), 1, 0) // Inside line segment
-expect("geom", geom.GetCell(N2-20, N2+4, N2+0), 1, 0) // Just barely within "round"
-expect("geom", geom.GetCell(N2-19, N2+4, N2+0), 1, 0) // Just barely within "round"
-expect("geom", geom.GetCell(N2-19, N2-4, N2+0), 0, 0) // Just barely not within "round"
-expect("geom", geom.GetCell(N2-20, N2+0, N2+4), 1, 0) // Just barely within "round"
-expect("geom", geom.GetCell(N2-20, N2+0, N2+5), 0, 0) // Just barely not within "round"
+expect("geom", geom.GetCell(N2-20, N2+4, N2+0), 1, 0) // Just barely within segment
+expect("geom", geom.GetCell(N2-19, N2+4, N2+0), 1, 0) // Just barely within segment
+expect("geom", geom.GetCell(N2-19, N2-4, N2+0), 0, 0) // Just barely not within segment nor "round"
+expect("geom", geom.GetCell(N2-20, N2+0, N2+4), 1, 0) // On segment boundary
+expect("geom", geom.GetCell(N2-20, N2+0, N2+5), 0, 0) // Just barely outside segment boundary
+expect("geom", geom.GetCell(N2-21, N2+0, N2+4), 0, 0) // Just barely outside "round"
+expect("geom", geom.GetCell(N2-21, N2+0, N2+3), 1, 0) // Just barely within "round"
 
 shape = Line(-20, 0, 0, 10, 5, 7, 4, "flat").Scale(c, c, c)
 SetGeom(shape)


### PR DESCRIPTION
As suggested by @Mat1629, this PR adds two new shapes to create lines. This can be convenient for, e.g., defining 3D ASI structures.

**`Line(x1, y1, z1, x2, y2, z2, diam, linecap)`** generates a line from $(x_1, y_1, z_1)$ to $(x_2, y_2, z_2)$ with a diameter `diam`. The behavior of the line at these two endpoints is determined by the last argument `linecap`, which can be
- `"infinite"`: the line extends indefinitely beyond the two specified points.
- `"round"`: a sphere of radius `diam` is placed at the two endpoints, yielding a smooth shape.
- `"flat"`: the line stops abruptly at the two endpoints in a flat plane perpendicular to the line.

**`Line2D(x1, y1, x2, y2, diam, linecap)`** behaves the same, but extends indefinitely along the Z-axis. Hence, this basically creates a plane in 3D space whose normal vector always lies in the XY-plane.

A special case was implemented for `diam=0`, in which case the shape will be a minimally connected geometry of all cells intersected by the line.
> [!WARNING]
> If a `diam=0` line is scaled or rotated afterwards, it is no longer guaranteed that this shape is fully connected, since the shape function then has no way of knowing what cells it would eventually intersect.

## Visual examples

Below are some geometries from `test/line.mx3` (but after an additional `relax()`).

|  | `Line` | `Line2D` |
| --- | --- | --- |
| `"round"` | <img width="716" height="742" alt="image" src="https://github.com/user-attachments/assets/b9871f67-8327-484c-a026-6723a3257ea5" /> | <img width="716" height="742" alt="image" src="https://github.com/user-attachments/assets/7bc60ceb-9569-4f4a-a624-f0173f9b97a1" /> |
| `"flat"` | <img width="716" height="742" alt="image" src="https://github.com/user-attachments/assets/4ac12170-4d9a-430d-a026-020c9f3a2225" /> | <img width="716" height="742" alt="image" src="https://github.com/user-attachments/assets/e22db2b2-e34c-443d-bc5d-89d8dd0ded33" /> |
| `"infinite"`  | <img width="716" height="742" alt="image" src="https://github.com/user-attachments/assets/bc924186-8d98-4a6d-9a24-76348fc9fea3" /> | <img width="716" height="742" alt="image" src="https://github.com/user-attachments/assets/28800a23-34e5-4141-be1a-952668a964ce" />|
 | `"infinite"` with `diam=0` | <img width="717" height="743" alt="image" src="https://github.com/user-attachments/assets/eb9d5ce6-7f00-40f8-953e-6164dcc0f806" /> | <img width="716" height="742" alt="image" src="https://github.com/user-attachments/assets/b8616bc2-255f-4f14-9559-7ba1e4999b77" /> |