### PR TITLE
Feature: RegionShapes

### DIFF
--- a/doc/templates/api-template.html
+++ b/doc/templates/api-template.html
@@ -42,7 +42,7 @@
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'mesh')">Mesh size and geometry</a></li>
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'shapes')">Shapes</a></li>
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'regions')">Material regions</a></li>
-    <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'initial')">Initial Magnetization</a></li>
+    <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'initial')">Initial magnetization</a></li>
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'parameters')">Material parameters</a></li>
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'excitation')">Excitation</a></li>
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'outputquantities')">Output quantities</a></li>

--- a/doc/templates/examples-template.html
+++ b/doc/templates/examples-template.html
@@ -222,7 +222,7 @@ saveas(geom, "imageShape")
 
 Note: these are 3D geometries seen from above. The displayed cell filling is averaged along the thickness (notable in ellipse and layers example). Black means empty space, white is filled.
 
-<hr/><h2 id="ex_initmag">Initial Magnetization</h2>
+<hr/><h2 id="ex_initmag">Initial magnetization</h2>
 Some initial magnetization functions are provided, as well as transformations similar to those on Shapes. See the Config <a href="http://mumax.github.io/api.html">API</a>.
 
 {{.Example `
@@ -280,7 +280,7 @@ These initial states are approximate, after setting them it is a good idea to re
 The magnetization can also be set in separate regions, see below.
 
 
-<hr/><h2 id="ex_cheese">Interlude: Rotating Cheese</h2>
+<hr/><h2 id="ex_cheese">Interlude: rotating cheese</h2>
 
 In this example we define a geometry that looks like a slice of cheese and have it rotate in time.
 
@@ -317,7 +317,7 @@ for i:=0; i<=90; i=i+30{
 {{.Output}}
 
 
-<hr/><h2 id="ex_regions">Regions: Space-dependent Parameters</h2>
+<hr/><h2 id="ex_regions">Regions: space-dependent parameters</h2>
 
 <p>Space-dependent parameters are defined using material <i>regions</i>. Regions are numbered 0-255 and represent different materials. Each cell can belong to only one region. At the start of a simulation all cells have region number 0.</p>
 
@@ -429,7 +429,7 @@ saveas(MFM, "lift_90nm")
 {{.Output}}
 
 
-<hr/><h2 id="ex_PMA">PMA Racetrack</h2>
+<hr/><h2 id="ex_PMA">PMA racetrack</h2>
 In this example we drive a domain wall in PMA material by spin-transfer torque.  We set up a post-step function that makes the simulation box "follow" the domain wall. Like this, only a small number of cells is needed to simulate an infinitely long magnetic wire.
 
 {{.Example `
@@ -463,7 +463,7 @@ run(.5e-9)
 Since we center on the domain wall we can not see that it is actually moving, but the domain wall breakdown is visible.
 
 
-<hr/><h2 id="ex_Py">Py Racetrack</h2>
+<hr/><h2 id="ex_Py">Py racetrack</h2>
 
 In this example we drive a vortex wall in Permalloy by spin-transfer torque. The simulation box "follows" the domain wall. By removing surface charges at the left and right ends, we mimic an infintely long wire.
 

--- a/engine/ext_regionshapes.go
+++ b/engine/ext_regionshapes.go
@@ -1,0 +1,34 @@
+package engine
+
+import (
+	"github.com/mumax/3/data"
+)
+
+func init() {
+	DeclFunc("AllRegionShapes", AllRegionShapes, "Returns a function that gives the shape of each region.")
+}
+
+func AllRegionShapes() func(int) Shape {
+	mesh := Mesh()
+	arr := regions.HostList()
+	n := mesh.Size()
+	d := mesh.CellSize()
+	Lx, Ly, Lz := float64(n[X])*d[X], float64(n[Y])*d[Y], float64(n[Z])*d[Z]
+
+	return func(region int) Shape {
+		defRegionId(region)
+
+		return func(x, y, z float64) bool {
+			ix := int((x + 0.5*Lx) / d[X])
+			iy := int((y + 0.5*Ly) / d[Y])
+			iz := int((z + 0.5*Lz) / d[Z])
+
+			if ix < 0 || ix >= n[X] || iy < 0 || iy >= n[Y] || iz < 0 || iz >= n[Z] {
+				return false
+			}
+
+			i := data.Index(n, ix, iy, iz)
+			return arr[i] == byte(region)
+		}
+	}
+}

--- a/engine/ext_regionshapes.go
+++ b/engine/ext_regionshapes.go
@@ -5,7 +5,7 @@ import (
 )
 
 func init() {
-	DeclFunc("ext_AllRegionShapes", ext_AllRegionShapes, "Returns a function that gives the shape of each region. Does not automatically update if the region is redefined or moved with Shift.")
+	DeclFunc("ext_AllRegionShapes", ext_AllRegionShapes, "Returns a function that gives the shape of each region. Does not automatically update if the region is redefined or moved with Shift. Call as: allregions := ext_AllRegionShapes(); shape := allregions(i); on seperate lines. Note: double parentheses as ext_AllRegionShapes()(i) are not supported in mx3 scripts and must be split across two lines.")
 }
 
 func ext_AllRegionShapes() func(int) Shape {

--- a/engine/ext_regionshapes.go
+++ b/engine/ext_regionshapes.go
@@ -5,10 +5,10 @@ import (
 )
 
 func init() {
-	DeclFunc("AllRegionShapes", AllRegionShapes, "Returns a function that gives the shape of each region.")
+	DeclFunc("ext_AllRegionShapes", ext_AllRegionShapes, "Returns a function that gives the shape of each region. Does not automatically update if the region is redefined or moved with Shift.")
 }
 
-func AllRegionShapes() func(int) Shape {
+func ext_AllRegionShapes() func(int) Shape {
 	mesh := Mesh()
 	arr := regions.HostList()
 	n := mesh.Size()

--- a/test/ext_AllRegionShapes.mx3
+++ b/test/ext_AllRegionShapes.mx3
@@ -1,0 +1,53 @@
+/*
+	Test the ext_AllRegionShapes extension, by comparing Shapes to Regions
+*/
+
+//This example uses Voronoi Tesselation regions, but ext_AllRegionShapes works with any other types of regions
+//Set arbitrary initial conditions
+N := 256
+c := 4e-9
+d := 40e-9
+setgridsize(N, N, 1)
+setcellsize(c, c, d)
+setGeom(circle(N*c))
+alpha = 3
+Kc1   = 1000
+Aex   = 13e-12
+Msat  = 860e3
+m=randommag()
+
+// define grains with region number 0-255
+grainSize  := 40e-9  // m
+randomSeed := 1234567
+maxRegion  := 254
+ext_makegrains(grainSize, maxRegion, randomSeed)
+
+//Zero out only half the regions, and save the average remaining magnetization
+for i:=0; i<maxRegion/2; i++{
+m.setregion(i,uniform(0,0,0))
+}
+
+mregionsavg:=m.average()
+
+//Reset so we can compare to Shapes equivalent
+m=randommag()
+
+// If we would like to add up several grains, we can initialize a shape with nothing in it, and then add to it in a loop.
+a:=circle(0e-9)
+
+//Initialize ext_Allregionshapes. By itself, ext_AllRegionShapes() is not yet a Shape, but still a func()
+//We can access the ith region using allregions(i). mx3 scripts do not allow double parentheses ext_AllRegionShapes()(i) on one line
+allregions:= ext_AllRegionShapes()
+
+//We can also add these Shapes in a loop. Here, add each Shape corresponding with the previous maxRegion/2 grains to compare
+for i:=0; i<maxRegion/2; i++{
+a=a.add(allregions(i))
+}
+//zero them out, as before
+m.setinshape(a,uniform(0,0,0))
+
+mshapesavg:=m.average()
+
+
+expectv("Average Magnetization",mregionsavg,mregionsavg,1e-8)
+


### PR DESCRIPTION
This PR adds a function `AllRegionShapes` which for a given region value, will return a Shape with all cells in that region. Can be easily looped over all 256 regions. This is intended mainly if one wants to make Shapes of say, Voronoi grains, to be used with Masked().

- An example file is including showing how each shape can be accessed after AllRegionShapes is called (there is some slightly unusual syntax, it uses 2 sets of parantheses), and also how they can be added together in a simple loop, is attached here: [regionshape_example.txt](https://github.com/user-attachments/files/26082150/regionshape_example.txt)

- does not yet work with shift/moving frame stuff. I am not sure if it could, or should?