### PR TITLE
Feature: GeometryEdgeFinder

### DIFF
--- a/doc/templates/api-template.html
+++ b/doc/templates/api-template.html
@@ -42,7 +42,7 @@
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'mesh')">Mesh size and geometry</a></li>
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'shapes')">Shapes</a></li>
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'regions')">Material regions</a></li>
-    <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'initial')">Initial Magnetization</a></li>
+    <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'initial')">Initial magnetization</a></li>
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'parameters')">Material parameters</a></li>
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'excitation')">Excitation</a></li>
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'outputquantities')">Output quantities</a></li>

--- a/doc/templates/examples-template.html
+++ b/doc/templates/examples-template.html
@@ -222,7 +222,7 @@ saveas(geom, "imageShape")
 
 Note: these are 3D geometries seen from above. The displayed cell filling is averaged along the thickness (notable in ellipse and layers example). Black means empty space, white is filled.
 
-<hr/><h2 id="ex_initmag">Initial Magnetization</h2>
+<hr/><h2 id="ex_initmag">Initial magnetization</h2>
 Some initial magnetization functions are provided, as well as transformations similar to those on Shapes. See the Config <a href="http://mumax.github.io/api.html">API</a>.
 
 {{.Example `
@@ -280,7 +280,7 @@ These initial states are approximate, after setting them it is a good idea to re
 The magnetization can also be set in separate regions, see below.
 
 
-<hr/><h2 id="ex_cheese">Interlude: Rotating Cheese</h2>
+<hr/><h2 id="ex_cheese">Interlude: rotating cheese</h2>
 
 In this example we define a geometry that looks like a slice of cheese and have it rotate in time.
 
@@ -317,7 +317,7 @@ for i:=0; i<=90; i=i+30{
 {{.Output}}
 
 
-<hr/><h2 id="ex_regions">Regions: Space-dependent Parameters</h2>
+<hr/><h2 id="ex_regions">Regions: space-dependent parameters</h2>
 
 <p>Space-dependent parameters are defined using material <i>regions</i>. Regions are numbered 0-255 and represent different materials. Each cell can belong to only one region. At the start of a simulation all cells have region number 0.</p>
 
@@ -429,7 +429,7 @@ saveas(MFM, "lift_90nm")
 {{.Output}}
 
 
-<hr/><h2 id="ex_PMA">PMA Racetrack</h2>
+<hr/><h2 id="ex_PMA">PMA racetrack</h2>
 In this example we drive a domain wall in PMA material by spin-transfer torque.  We set up a post-step function that makes the simulation box "follow" the domain wall. Like this, only a small number of cells is needed to simulate an infinitely long magnetic wire.
 
 {{.Example `
@@ -463,7 +463,7 @@ run(.5e-9)
 Since we center on the domain wall we can not see that it is actually moving, but the domain wall breakdown is visible.
 
 
-<hr/><h2 id="ex_Py">Py Racetrack</h2>
+<hr/><h2 id="ex_Py">Py racetrack</h2>
 
 In this example we drive a vortex wall in Permalloy by spin-transfer torque. The simulation box "follows" the domain wall. By removing surface charges at the left and right ends, we mimic an infintely long wire.
 

--- a/engine/ext_geomedgefinder.go
+++ b/engine/ext_geomedgefinder.go
@@ -1,0 +1,128 @@
+package engine
+
+import (
+	"math"
+
+	"github.com/mumax/3/cuda"
+)
+
+func init() {
+	DeclFunc("GeometryEdgePlusX", GeometryEdgePlusX, "Returns the +X edge of the geometry as a Shape")
+	DeclFunc("GeometryEdgeMinusX", GeometryEdgeMinusX, "Returns the -X edge of the geometry as a Shape")
+	DeclFunc("GeometryEdgePlusY", GeometryEdgePlusY, "Returns the +Y edge of the geometry as a Shape")
+	DeclFunc("GeometryEdgeMinusY", GeometryEdgeMinusY, "Returns the -Y edge of the geometry as a Shape")
+	DeclFunc("GeometryEdgePlusZ", GeometryEdgePlusZ, "Returns the +Z edge of the geometry as a Shape")
+	DeclFunc("GeometryEdgeMinusZ", GeometryEdgeMinusZ, "Returns the -Z edge of the geometry as a Shape")
+}
+
+func GeometryEdgePlusX() Shape {
+	plusX, _, _, _, _, _ := GeometryEdges()
+	return plusX
+}
+
+func GeometryEdgeMinusX() Shape {
+	_, minusX, _, _, _, _ := GeometryEdges()
+	return minusX
+}
+
+func GeometryEdgePlusY() Shape {
+	_, _, plusY, _, _, _ := GeometryEdges()
+	return plusY
+}
+
+func GeometryEdgeMinusY() Shape {
+	_, _, _, minusY, _, _ := GeometryEdges()
+	return minusY
+}
+
+func GeometryEdgePlusZ() Shape {
+	_, _, _, _, plusZ, _ := GeometryEdges()
+	return plusZ
+}
+
+func GeometryEdgeMinusZ() Shape {
+	_, _, _, _, _, minusZ := GeometryEdges()
+	return minusZ
+}
+
+func GeometryEdges() (plusX, minusX, plusY, minusY, plusZ, minusZ Shape) {
+
+	s, r := geometry.Slice()
+	if r {
+		defer cuda.Recycle(s)
+	}
+
+	arr3d := s.HostCopy().Scalars()
+
+	n := Mesh().Size()
+	Nx, Ny, Nz := n[X], n[Y], n[Z]
+
+	edgeMasks := make([][]bool, 6)
+	for i := range edgeMasks {
+		edgeMasks[i] = make([]bool, Nx*Ny*Nz)
+	}
+
+	for k := 0; k < Nz; k++ {
+		for j := 0; j < Ny; j++ {
+			for i := 0; i < Nx; i++ {
+				if arr3d[k][j][i] == 0 {
+					continue
+				}
+
+				neighborX, neighborY, neighborZ := i+1, j, k
+				if neighborX < 0 || neighborX >= Nx || arr3d[neighborZ][neighborY][neighborX] == 0 {
+					edgeMasks[0][(k*Ny+j)*Nx+i] = true
+				}
+
+				neighborX, neighborY, neighborZ = i-1, j, k
+				if neighborX < 0 || neighborX >= Nx || arr3d[neighborZ][neighborY][neighborX] == 0 {
+					edgeMasks[1][(k*Ny+j)*Nx+i] = true
+				}
+
+				neighborX, neighborY, neighborZ = i, j+1, k
+				if neighborY < 0 || neighborY >= Ny || arr3d[neighborZ][neighborY][neighborX] == 0 {
+					edgeMasks[2][(k*Ny+j)*Nx+i] = true
+				}
+
+				neighborX, neighborY, neighborZ = i, j-1, k
+				if neighborY < 0 || neighborY >= Ny || arr3d[neighborZ][neighborY][neighborX] == 0 {
+					edgeMasks[3][(k*Ny+j)*Nx+i] = true
+				}
+
+				neighborX, neighborY, neighborZ = i, j, k+1
+				if neighborZ < 0 || neighborZ >= Nz || arr3d[neighborZ][neighborY][neighborX] == 0 {
+					edgeMasks[4][(k*Ny+j)*Nx+i] = true
+				}
+
+				neighborX, neighborY, neighborZ = i, j, k-1
+				if neighborZ < 0 || neighborZ >= Nz || arr3d[neighborZ][neighborY][neighborX] == 0 {
+					edgeMasks[5][(k*Ny+j)*Nx+i] = true
+				}
+
+			}
+		}
+	}
+
+	return maskToShape(edgeMasks[0], Nx, Ny, Nz), maskToShape(edgeMasks[1], Nx, Ny, Nz),
+		maskToShape(edgeMasks[2], Nx, Ny, Nz), maskToShape(edgeMasks[3], Nx, Ny, Nz),
+		maskToShape(edgeMasks[4], Nx, Ny, Nz), maskToShape(edgeMasks[5], Nx, Ny, Nz)
+}
+
+// Helper function to wrap bool mask into a Shape
+func maskToShape(mask []bool, Nx, Ny, Nz int) Shape {
+	return func(x, y, z float64) bool {
+		d := Mesh().CellSize()
+		Lx := float64(Nx) * d[X]
+		Ly := float64(Ny) * d[Y]
+		Lz := float64(Nz) * d[Z]
+
+		ix := int(math.Floor((x + 0.5*Lx) / d[X]))
+		iy := int(math.Floor((y + 0.5*Ly) / d[Y]))
+		iz := int(math.Floor((z + 0.5*Lz) / d[Z]))
+
+		if ix < 0 || ix >= Nx || iy < 0 || iy >= Ny || iz < 0 || iz >= Nz {
+			return false
+		}
+		return mask[(iz*Ny+iy)*Nx+ix]
+	}
+}

--- a/engine/ext_geomedgefinder.go
+++ b/engine/ext_geomedgefinder.go
@@ -44,6 +44,11 @@ func ext_GeomEdge(axis string) Shape {
 		util.Log("GeometryEdge: invalid direction '" + axis + "'. Use +x, -x, +y, -y, +z, or -z")
 	}
 
+	PBCc := Mesh().PBC_code()
+	PBCx := (PBCc >> X) & 1
+	PBCy := (PBCc >> Y) & 1
+	PBCz := (PBCc >> Z) & 1
+
 	for k := 0; k < Nz; k++ {
 		for j := 0; j < Ny; j++ {
 			for i := 0; i < Nx; i++ {
@@ -52,7 +57,14 @@ func ext_GeomEdge(axis string) Shape {
 					continue
 				}
 
-				nx, ny, nz := i+offx, j+offy, k+offz
+				wrapPBC := func(i, N int, PBC byte) int {
+					if PBC == 0 {
+						return i // Don't wrap
+					}
+					return ((i % N) + N) % N // Wrap in integer range [0, N-1]
+				}
+
+				nx, ny, nz := wrapPBC(i+offx, Nx, PBCx), wrapPBC(j+offy, Ny, PBCy), wrapPBC(k+offz, Nz, PBCz)
 				if nx < 0 || nx >= Nx || ny < 0 || ny >= Ny || nz < 0 || nz >= Nz || arr3d[nz][ny][nx] == 0 {
 					edgemask[(k*Ny+j)*Nx+i] = true
 				}
@@ -60,7 +72,15 @@ func ext_GeomEdge(axis string) Shape {
 		}
 	}
 
-	return maskToShape(edgemask)
+	if PBCc != 0 { // Account for PBC in case of Grid resize by repeating GeomEdge
+		d := Mesh().CellSize()
+		Rx := float64(Nx) * d[X] * float64(PBCx)
+		Ry := float64(Ny) * d[Y] * float64(PBCy)
+		Rz := float64(Nz) * d[Z] * float64(PBCz)
+		return maskToShape(edgemask).Repeat(Rx, Ry, Rz)
+	} else { // No PBC
+		return maskToShape(edgemask)
+	}
 }
 
 // Helper function to wrap bool mask into a Shape

--- a/engine/ext_geomedgefinder.go
+++ b/engine/ext_geomedgefinder.go
@@ -9,10 +9,10 @@ import (
 )
 
 func init() {
-	DeclFunc("ext_GeometryEdge", ext_GeometryEdge, "Returns an edge (+x, -x, +y, -y, +z, -z) of the geometry as a Shape. The Shape may not update automatically after changes to the mesh or geometry; rerun the function to refresh.")
+	DeclFunc("ext_GeomEdge", ext_GeomEdge, "Returns an edge (+x, -x, +y, -y, +z, -z) of the geometry as a Shape. The Shape may not update automatically after changes to the mesh or geometry; rerun the function to refresh.")
 }
 
-func ext_GeometryEdge(axis string) Shape {
+func ext_GeomEdge(axis string) Shape {
 
 	s, r := geometry.Slice()
 	if r {

--- a/engine/ext_geomedgefinder.go
+++ b/engine/ext_geomedgefinder.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"math"
+	"strings"
 
 	"github.com/mumax/3/cuda"
 	"github.com/mumax/3/util"
@@ -26,7 +27,7 @@ func ext_GeometryEdge(axis string) Shape {
 	edgemask := make([]bool, Nx*Ny*Nz)
 
 	var offx, offy, offz int
-	switch axis {
+	switch strings.ToLower(axis) {
 	case "+x":
 		offx, offy, offz = 1, 0, 0
 	case "-x":

--- a/engine/ext_geomedgefinder.go
+++ b/engine/ext_geomedgefinder.go
@@ -23,6 +23,7 @@ func ext_GeomEdge(axis string) Shape {
 
 	n := Mesh().Size()
 	Nx, Ny, Nz := n[X], n[Y], n[Z]
+	PBC := Mesh().PBC()
 
 	edgemask := make([]bool, Nx*Ny*Nz)
 
@@ -44,11 +45,6 @@ func ext_GeomEdge(axis string) Shape {
 		util.Log("GeometryEdge: invalid direction '" + axis + "'. Use +x, -x, +y, -y, +z, or -z")
 	}
 
-	PBCc := Mesh().PBC_code()
-	PBCx := (PBCc >> X) & 1
-	PBCy := (PBCc >> Y) & 1
-	PBCz := (PBCc >> Z) & 1
-
 	for k := 0; k < Nz; k++ {
 		for j := 0; j < Ny; j++ {
 			for i := 0; i < Nx; i++ {
@@ -57,14 +53,14 @@ func ext_GeomEdge(axis string) Shape {
 					continue
 				}
 
-				wrapPBC := func(i, N int, PBC byte) int {
+				wrapPBC := func(i, N, PBC int) int {
 					if PBC == 0 {
 						return i // Don't wrap
 					}
 					return ((i % N) + N) % N // Wrap in integer range [0, N-1]
 				}
 
-				nx, ny, nz := wrapPBC(i+offx, Nx, PBCx), wrapPBC(j+offy, Ny, PBCy), wrapPBC(k+offz, Nz, PBCz)
+				nx, ny, nz := wrapPBC(i+offx, Nx, PBC[X]), wrapPBC(j+offy, Ny, PBC[Y]), wrapPBC(k+offz, Nz, PBC[Z])
 				if nx < 0 || nx >= Nx || ny < 0 || ny >= Ny || nz < 0 || nz >= Nz || arr3d[nz][ny][nx] == 0 {
 					edgemask[(k*Ny+j)*Nx+i] = true
 				}
@@ -72,11 +68,11 @@ func ext_GeomEdge(axis string) Shape {
 		}
 	}
 
-	if PBCc != 0 { // Account for PBC in case of Grid resize by repeating GeomEdge
+	if PBC[X] != 0 || PBC[Y] != 0 || PBC[Z] != 0 { // Account for PBC in case of Grid resize by repeating GeomEdge
 		d := Mesh().CellSize()
-		Rx := float64(Nx) * d[X] * float64(PBCx)
-		Ry := float64(Ny) * d[Y] * float64(PBCy)
-		Rz := float64(Nz) * d[Z] * float64(PBCz)
+		Rx := float64(Nx) * d[X] * float64(PBC[X]&1)
+		Ry := float64(Ny) * d[Y] * float64(PBC[Y]&1)
+		Rz := float64(Nz) * d[Z] * float64(PBC[Z]&1)
 		return maskToShape(edgemask).Repeat(Rx, Ry, Rz)
 	} else { // No PBC
 		return maskToShape(edgemask)

--- a/engine/ext_geomedgefinder.go
+++ b/engine/ext_geomedgefinder.go
@@ -4,48 +4,14 @@ import (
 	"math"
 
 	"github.com/mumax/3/cuda"
+	"github.com/mumax/3/util"
 )
 
 func init() {
-	DeclFunc("GeometryEdgePlusX", GeometryEdgePlusX, "Returns the +X edge of the geometry as a Shape")
-	DeclFunc("GeometryEdgeMinusX", GeometryEdgeMinusX, "Returns the -X edge of the geometry as a Shape")
-	DeclFunc("GeometryEdgePlusY", GeometryEdgePlusY, "Returns the +Y edge of the geometry as a Shape")
-	DeclFunc("GeometryEdgeMinusY", GeometryEdgeMinusY, "Returns the -Y edge of the geometry as a Shape")
-	DeclFunc("GeometryEdgePlusZ", GeometryEdgePlusZ, "Returns the +Z edge of the geometry as a Shape")
-	DeclFunc("GeometryEdgeMinusZ", GeometryEdgeMinusZ, "Returns the -Z edge of the geometry as a Shape")
+	DeclFunc("ext_GeometryEdge", ext_GeometryEdge, "Returns an edge (+x, -x, +y, -y, +z, -z) of the geometry as a Shape. The Shape may not update automatically after changes to the mesh or geometry; rerun the function to refresh.")
 }
 
-func GeometryEdgePlusX() Shape {
-	plusX, _, _, _, _, _ := GeometryEdges()
-	return plusX
-}
-
-func GeometryEdgeMinusX() Shape {
-	_, minusX, _, _, _, _ := GeometryEdges()
-	return minusX
-}
-
-func GeometryEdgePlusY() Shape {
-	_, _, plusY, _, _, _ := GeometryEdges()
-	return plusY
-}
-
-func GeometryEdgeMinusY() Shape {
-	_, _, _, minusY, _, _ := GeometryEdges()
-	return minusY
-}
-
-func GeometryEdgePlusZ() Shape {
-	_, _, _, _, plusZ, _ := GeometryEdges()
-	return plusZ
-}
-
-func GeometryEdgeMinusZ() Shape {
-	_, _, _, _, _, minusZ := GeometryEdges()
-	return minusZ
-}
-
-func GeometryEdges() (plusX, minusX, plusY, minusY, plusZ, minusZ Shape) {
+func ext_GeometryEdge(axis string) Shape {
 
 	s, r := geometry.Slice()
 	if r {
@@ -57,61 +23,52 @@ func GeometryEdges() (plusX, minusX, plusY, minusY, plusZ, minusZ Shape) {
 	n := Mesh().Size()
 	Nx, Ny, Nz := n[X], n[Y], n[Z]
 
-	edgeMasks := make([][]bool, 6)
-	for i := range edgeMasks {
-		edgeMasks[i] = make([]bool, Nx*Ny*Nz)
+	edgemask := make([]bool, Nx*Ny*Nz)
+
+	var offx, offy, offz int
+	switch axis {
+	case "+x":
+		offx, offy, offz = 1, 0, 0
+	case "-x":
+		offx, offy, offz = -1, 0, 0
+	case "+y":
+		offx, offy, offz = 0, 1, 0
+	case "-y":
+		offx, offy, offz = 0, -1, 0
+	case "+z":
+		offx, offy, offz = 0, 0, 1
+	case "-z":
+		offx, offy, offz = 0, 0, -1
+	default:
+		util.Log("GeometryEdge: invalid direction '" + axis + "'. Use +x, -x, +y, -y, +z, or -z")
 	}
 
 	for k := 0; k < Nz; k++ {
 		for j := 0; j < Ny; j++ {
 			for i := 0; i < Nx; i++ {
+
 				if arr3d[k][j][i] == 0 {
 					continue
 				}
 
-				neighborX, neighborY, neighborZ := i+1, j, k
-				if neighborX < 0 || neighborX >= Nx || arr3d[neighborZ][neighborY][neighborX] == 0 {
-					edgeMasks[0][(k*Ny+j)*Nx+i] = true
+				nx, ny, nz := i+offx, j+offy, k+offz
+				if nx < 0 || nx >= Nx || ny < 0 || ny >= Ny || nz < 0 || nz >= Nz || arr3d[nz][ny][nx] == 0 {
+					edgemask[(k*Ny+j)*Nx+i] = true
 				}
-
-				neighborX, neighborY, neighborZ = i-1, j, k
-				if neighborX < 0 || neighborX >= Nx || arr3d[neighborZ][neighborY][neighborX] == 0 {
-					edgeMasks[1][(k*Ny+j)*Nx+i] = true
-				}
-
-				neighborX, neighborY, neighborZ = i, j+1, k
-				if neighborY < 0 || neighborY >= Ny || arr3d[neighborZ][neighborY][neighborX] == 0 {
-					edgeMasks[2][(k*Ny+j)*Nx+i] = true
-				}
-
-				neighborX, neighborY, neighborZ = i, j-1, k
-				if neighborY < 0 || neighborY >= Ny || arr3d[neighborZ][neighborY][neighborX] == 0 {
-					edgeMasks[3][(k*Ny+j)*Nx+i] = true
-				}
-
-				neighborX, neighborY, neighborZ = i, j, k+1
-				if neighborZ < 0 || neighborZ >= Nz || arr3d[neighborZ][neighborY][neighborX] == 0 {
-					edgeMasks[4][(k*Ny+j)*Nx+i] = true
-				}
-
-				neighborX, neighborY, neighborZ = i, j, k-1
-				if neighborZ < 0 || neighborZ >= Nz || arr3d[neighborZ][neighborY][neighborX] == 0 {
-					edgeMasks[5][(k*Ny+j)*Nx+i] = true
-				}
-
 			}
 		}
 	}
 
-	return maskToShape(edgeMasks[0], Nx, Ny, Nz), maskToShape(edgeMasks[1], Nx, Ny, Nz),
-		maskToShape(edgeMasks[2], Nx, Ny, Nz), maskToShape(edgeMasks[3], Nx, Ny, Nz),
-		maskToShape(edgeMasks[4], Nx, Ny, Nz), maskToShape(edgeMasks[5], Nx, Ny, Nz)
+	return maskToShape(edgemask)
 }
 
 // Helper function to wrap bool mask into a Shape
-func maskToShape(mask []bool, Nx, Ny, Nz int) Shape {
+func maskToShape(mask []bool) Shape {
+	n := Mesh().Size()
+	Nx, Ny, Nz := n[X], n[Y], n[Z]
+	d := Mesh().CellSize()
+
 	return func(x, y, z float64) bool {
-		d := Mesh().CellSize()
 		Lx := float64(Nx) * d[X]
 		Ly := float64(Ny) * d[Y]
 		Lz := float64(Nz) * d[Z]

--- a/test/ext_GeometryEdge.mx3
+++ b/test/ext_GeometryEdge.mx3
@@ -1,0 +1,72 @@
+/*
+    This test primarily serves as a visual verification of the ext_geomEdge() functionality,
+    but also performs two automated tests for particular analytically describable cases with PBC along X and Z.
+*/
+
+N := 21
+c := 5e-9
+d := 115e-9
+
+SetCellSize(c, c, c)
+SetGridSize(N, N, N)
+SetPBC(1,0,1) // Mix of PBC and OBC to simultaneously check behavior for both cases
+
+m = Uniform(-1, 0, 0)
+shape := SuperBall(d, 1.5) // Shape with analytical expression available
+SetGeom(shape)
+SaveAs(m, "m_orig.ovf")
+
+PlusX := ext_GeomEdge("+X")
+PlusY := ext_GeomEdge("+Y")
+MinZ := ext_GeomEdge("-Z")
+
+SetGeom(PlusX)
+SaveAs(m, "m_+X.ovf")
+SetGeom(PlusY)
+SaveAs(m, "m_+Y.ovf")
+SetGeom(MinZ)
+SaveAs(m, "m_-Z.ovf")
+
+//// Double grid size to see effect of PBC
+SetGridSize(2*N+1, 2*N+1, 2*N+1)
+
+SetGeom(PlusX)
+SaveAs(m, "m_+X_PBC.ovf")
+for iz := 0; iz < 2*N-1; iz++ {
+    for iy := 0; iy < 2*N-1; iy++ {
+        totalCells := 0
+        for ix := 0; ix < 2*N-1; ix++ {
+            totalCells += geom.GetCell(ix, iy, iz)
+        }
+        v := Index2Coord(0, iy, iz)
+        r := Pow(2*Abs(v.Y())/d, 3) + Pow(Abs(2*(Mod(Abs(v.Z()) + N*c/2, N*c) - N*c/2))/d, 3)
+        if ((r <= 1) && (r >= (1 - Pow((N-1)*c/d, 3))) && iy > N/2 && iy < 3*N/2) { // Superball shape in YZ-plane
+            Expect("+X_PBC: One cell thick along X", totalCells, 2, 0)
+        } else {
+            Expect("+X_PBC: No cells along X", totalCells, 0, 0)
+        }
+    }
+}
+
+SetGeom(PlusX.Add(PlusY))
+SaveAs(m, "m_+X+Y.ovf")
+for iz := 0; iz < 2*N-1; iz++ {
+    for ix := 0; ix < 2*N-1; ix++ {
+        totalCells := 0
+        for iy := 0; iy < 2*N-1; iy++ {
+            totalCells += geom.GetCell(ix, iy, iz)
+        }
+        v := Index2Coord(ix, 0, iz)
+        r := Pow(Abs(2*(Mod(Abs(v.X()) + N*c/2, N*c) - N*c/2))/d, 3) + Pow(Abs(2*(Mod(Abs(v.Z()) + N*c/2, N*c) - N*c/2))/d, 3)
+        if (r <= 1 - Pow((N+1)*c/d, 3)) { // Superball shape in XZ-plane
+            Expect("+X+Y_PBC: One cell thick along X", totalCells, 1, 0)
+        } else if (r <= 1) {
+            Expect("+X+Y_PBC: Area with possibly multiple cells along X", sign(totalCells), 1, 0)
+        } else {
+            Expect("+X+Y_PBC: No cells along X", totalCells, 0, 0)
+        }
+    }
+}
+
+SetGeom(PlusX.Add(PlusY.Intersect(MinZ)))
+SaveAs(m, "m_+X+Y-Z.ovf")


### PR DESCRIPTION
This PR adds a helper function that makes edges of the geometry (1 cell thick) into Shapes, allowing the user to easily define things for e.g. custom fields boundary conditions. By default, there are 6 Shapes corresponding to: +/- X, Y, Z edges.

- 2s permutations (corners such as +/- XY, etc) can be done by using existing Shape method .intersect(). 3s as well.
- Treats the edge of the simulation box as geometry edge. Does **not** currently check if PBC are enabled.
- example file attached: [geomedgefinder_example.txt](https://github.com/user-attachments/files/26082803/geomedgefinder_example.txt)
