### PR TITLE
Bugfix: fix typo for 255 check in regions.go

### DIFF
--- a/doc/templates/api-template.html
+++ b/doc/templates/api-template.html
@@ -42,7 +42,7 @@
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'mesh')">Mesh size and geometry</a></li>
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'shapes')">Shapes</a></li>
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'regions')">Material regions</a></li>
-    <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'initial')">Initial Magnetization</a></li>
+    <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'initial')">Initial magnetization</a></li>
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'parameters')">Material parameters</a></li>
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'excitation')">Excitation</a></li>
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'outputquantities')">Output quantities</a></li>

--- a/doc/templates/api-template.html
+++ b/doc/templates/api-template.html
@@ -211,7 +211,7 @@ tableAdd(m.Region(1))    // add average m over region 1 to table
 
 	<hr/>
 	
-	{{range .FilterName "DefRegion" "DefRegionCell" "ReDefRegion" "regions"}} {{template "entry" .}} {{end}}
+	{{range .FilterName "DefRegion" "DefRegionCell" "ReDefRegion" "regions" "NREGION"}} {{template "entry" .}} {{end}}
 
 </div>
 

--- a/doc/templates/examples-template.html
+++ b/doc/templates/examples-template.html
@@ -525,7 +525,7 @@ randomSeed := 1234567
 maxRegion  := 255
 ext_makegrains(grainSize, maxRegion, randomSeed)
 
-defregion(256, circle(N*c).inverse()) // region 256 is outside, not really needed
+defregion(0, circle(N*c).inverse()) // region 0 is outside, not really needed
 
 alpha = 3
 Kc1   = 1000

--- a/doc/templates/examples-template.html
+++ b/doc/templates/examples-template.html
@@ -222,7 +222,7 @@ saveas(geom, "imageShape")
 
 Note: these are 3D geometries seen from above. The displayed cell filling is averaged along the thickness (notable in ellipse and layers example). Black means empty space, white is filled.
 
-<hr/><h2 id="ex_initmag">Initial Magnetization</h2>
+<hr/><h2 id="ex_initmag">Initial magnetization</h2>
 Some initial magnetization functions are provided, as well as transformations similar to those on Shapes. See the Config <a href="http://mumax.github.io/api.html">API</a>.
 
 {{.Example `
@@ -280,7 +280,7 @@ These initial states are approximate, after setting them it is a good idea to re
 The magnetization can also be set in separate regions, see below.
 
 
-<hr/><h2 id="ex_cheese">Interlude: Rotating Cheese</h2>
+<hr/><h2 id="ex_cheese">Interlude: rotating cheese</h2>
 
 In this example we define a geometry that looks like a slice of cheese and have it rotate in time.
 
@@ -317,7 +317,7 @@ for i:=0; i<=90; i=i+30{
 {{.Output}}
 
 
-<hr/><h2 id="ex_regions">Regions: Space-dependent Parameters</h2>
+<hr/><h2 id="ex_regions">Regions: space-dependent parameters</h2>
 
 <p>Space-dependent parameters are defined using material <i>regions</i>. Regions are numbered 0-255 and represent different materials. Each cell can belong to only one region. At the start of a simulation all cells have region number 0.</p>
 
@@ -429,7 +429,7 @@ saveas(MFM, "lift_90nm")
 {{.Output}}
 
 
-<hr/><h2 id="ex_PMA">PMA Racetrack</h2>
+<hr/><h2 id="ex_PMA">PMA racetrack</h2>
 In this example we drive a domain wall in PMA material by spin-transfer torque.  We set up a post-step function that makes the simulation box "follow" the domain wall. Like this, only a small number of cells is needed to simulate an infinitely long magnetic wire.
 
 {{.Example `
@@ -463,7 +463,7 @@ run(.5e-9)
 Since we center on the domain wall we can not see that it is actually moving, but the domain wall breakdown is visible.
 
 
-<hr/><h2 id="ex_Py">Py Racetrack</h2>
+<hr/><h2 id="ex_Py">Py racetrack</h2>
 
 In this example we drive a vortex wall in Permalloy by spin-transfer torque. The simulation box "follows" the domain wall. By removing surface charges at the left and right ends, we mimic an infintely long wire.
 

--- a/doc/templates/examples-template.html
+++ b/doc/templates/examples-template.html
@@ -522,7 +522,7 @@ setGeom(circle(N*c))
 // define grains with region number 0-255
 grainSize  := 40e-9  // m
 randomSeed := 1234567
-maxRegion  := 255
+maxRegion  := NREGION - 1
 ext_makegrains(grainSize, maxRegion, randomSeed)
 
 defregion(0, circle(N*c).inverse()) // region 0 is outside, not really needed
@@ -666,7 +666,7 @@ c := 5e-9
 setgridsize(Nx, Ny, 1)
 setcellsize(c, c, c)
 
-ext_makegrains(30e-9, 256, 0)
+ext_makegrains(30e-9, NREGION, 0)
 
 // PMA material
 Ku1   = 0.4e6
@@ -676,12 +676,12 @@ alpha = 1
 
 delta := 0.2 // anisotropy variation
 
-for i:=0; i<256; i++{
+for i:=0; i<NREGION; i++{
 	// random cubic anisotropy direction
 	AnisU.SetRegion(i, vector(delta*(rand()-0.5), delta*(rand()-0.5), 1))
 
 	// strongly reduce exchange coupling between grains
-	for j:=i+1; j<256; j++{
+	for j:=i+1; j<NREGION; j++{
 		ext_scaleExchange(i, j, 0.1)
 	}
 }

--- a/engine/regions.go
+++ b/engine/regions.go
@@ -14,6 +14,7 @@ func init() {
 	DeclFunc("DefRegion", DefRegion, "Define a material region with given index (0-255) and shape")
 	DeclFunc("RedefRegion", RedefRegion, "Reassign all cells with a given region (first argument) to a new region (second argument)")
 	DeclROnly("regions", &regions, "Outputs the region index for each cell")
+	DeclROnly("NREGION", NREGION, "Maximum number of regions (256)")
 	DeclFunc("DefRegionCell", DefRegionCell, "Set a material region (first argument) in one cell "+
 		"by the index of the cell (last three arguments)")
 }
@@ -165,7 +166,7 @@ func (r *Regions) LoadFile(fname string) {
 			for ix := 0; ix < n[X]; ix++ {
 				val := inArr[iz][iy][ix]
 				if val < 0 || val >= NREGION {
-					util.Fatal("regions.LoadFile(", fname, "): all values should be between 0 & 256, have: ", val)
+					util.Fatal("regions.LoadFile(", fname, "): all values should be between 0 & ", NREGION-1, ", have: ", val)
 				}
 				arr[iz][iy][ix] = byte(val)
 			}
@@ -199,7 +200,7 @@ func (r *Regions) GetCell(ix, iy, iz int) int {
 
 func defRegionId(id int) {
 	if id < 0 || id >= NREGION {
-		util.Fatalf("region id should be 0 -%v, have: %v", NREGION, id)
+		util.Fatalf("region id should be 0 - %v, have: %v", NREGION-1, id)
 	}
 	checkMesh()
 }

--- a/engine/regions.go
+++ b/engine/regions.go
@@ -164,7 +164,7 @@ func (r *Regions) LoadFile(fname string) {
 		for iy := 0; iy < n[Y]; iy++ {
 			for ix := 0; ix < n[X]; ix++ {
 				val := inArr[iz][iy][ix]
-				if val < 0 || val > 256 {
+				if val < 0 || val >= NREGION {
 					util.Fatal("regions.LoadFile(", fname, "): all values should be between 0 & 256, have: ", val)
 				}
 				arr[iz][iy][ix] = byte(val)
@@ -198,7 +198,7 @@ func (r *Regions) GetCell(ix, iy, iz int) int {
 }
 
 func defRegionId(id int) {
-	if id < 0 || id > NREGION {
+	if id < 0 || id >= NREGION {
 		util.Fatalf("region id should be 0 -%v, have: %v", NREGION, id)
 	}
 	checkMesh()

--- a/test/bubbleshiftpos.mx3
+++ b/test/bubbleshiftpos.mx3
@@ -10,7 +10,7 @@ Dind=0.0034089785
 
 shiftregions=true
 
-maxregion:=255
+maxregion:=NREGION - 1
 seed:=17
 ext_makegrains(10e-9, maxregion, seed)
 

--- a/test/exchcoupling.mx3
+++ b/test/exchcoupling.mx3
@@ -12,7 +12,7 @@ randomSeed := 1234567
 maxRegion  := 255
 ext_makegrains(grainSize, maxRegion, randomSeed)
 
-defregion(256, circle(N*c).inverse()) // region 256 is outside, not really needed
+defregion(0, circle(N*c).inverse()) // region 0 is outside, not really needed
 
 alpha = 3
 Kc1   = 1000

--- a/test/exchcoupling.mx3
+++ b/test/exchcoupling.mx3
@@ -9,7 +9,7 @@ setGeom(circle(N*c))
 // define grains with region number 0-255
 grainSize  := 40e-9  // m
 randomSeed := 1234567
-maxRegion  := 255
+maxRegion  := NREGION - 1
 ext_makegrains(grainSize, maxRegion, randomSeed)
 
 defregion(0, circle(N*c).inverse()) // region 0 is outside, not really needed

--- a/test/fixedlayer.mx3
+++ b/test/fixedlayer.mx3
@@ -43,7 +43,7 @@ J = vector(0, 0, jc)
 
 grainSize := 4e-9 // m
 
-maxRegion := 255
+maxRegion := NREGION - 1
 ext_makegrains(grainSize, maxRegion, randomSeed)
 
 for i := 0; i < maxRegion; i++ {

--- a/test/make3dgrains.mx3
+++ b/test/make3dgrains.mx3
@@ -21,8 +21,9 @@ for i:=100; i<200; i+=1 {
 }
 
 //Scale the exchange interaction between all grains
-for i:=1; i<255; i+=1 {
-	for j:=i; j<255; j+=1 {
+maxRegion := NREGION - 1
+for i:=1; i<maxRegion; i+=1 {
+	for j:=i; j<maxRegion; j+=1 {
 		ext_scaleExchange(i,j,0.9)
 	}
 }

--- a/test/regionsload.mx3
+++ b/test/regionsload.mx3
@@ -14,7 +14,7 @@ m.setRegion(2, uniform(0, 1, 0))
 saveAs(regions, "regions.ovf")
 
 // overwrite regions
-defregion(256, universe())
+defregion(0, universe())
 
 // re-load previous state from disk
 regions.loadFile("testdata/regions.ovf")

--- a/test/regression003.mx3
+++ b/test/regression003.mx3
@@ -8,7 +8,7 @@ setcellsize(c, c, c)
 
 m = uniform(1,0,0) 
 
-ext_makegrains(40e-9, 255, 0)
+ext_makegrains(40e-9, NREGION-1, 0)
 defregion(1, circle(200*c))
 defregion(2, circle(100*c))
 defregion(128, circle(50*c))

--- a/test/shiftgrains.mx3
+++ b/test/shiftgrains.mx3
@@ -13,13 +13,13 @@ m = twodomain(1,0,0, 0,1,0, -1,0,0)
 Aex = 13e-12
 Msat = 800e3
 
-ext_makegrains(40e-9, 255, 0)
+ext_makegrains(40e-9, NREGION-1, 0)
 ext_rmsurfacecharge(0, 1, -1)
 ext_centerwall(0)
 
 alpha = 1
 
-for i:=0; i<255; i++{
+for i:=0; i<NREGION-1; i++{
 	Aex.SetRegion(i, 13e-12 + randNorm()*1.3e-12)
 	Msat.SetRegion(i, 800e3 + randNorm()*80e3)
 }


### PR DESCRIPTION
I think there may be two typos in the max number of allowed regions?

In regions.Loadfile() and defRegionId(), it checks if regions are >256. However, I believe this should be >=256? Regions allows 256 regions (0-255), but it should not allow 256. 


There is a similar typo in the Voronoi example on the website example page: The line:
"defregion(256, circle(N*c).inverse())". 

The Setgeom() command in the example moots it, but 256 actually wraps back to region 0. (This PR does not fix this)