### PR TITLE
Re-expose Voxelshape to user

### DIFF
--- a/doc/templates/api-template.html
+++ b/doc/templates/api-template.html
@@ -42,7 +42,7 @@
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'mesh')">Mesh size and geometry</a></li>
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'shapes')">Shapes</a></li>
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'regions')">Material regions</a></li>
-    <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'initial')">Initial Magnetization</a></li>
+    <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'initial')">Initial magnetization</a></li>
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'parameters')">Material parameters</a></li>
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'excitation')">Excitation</a></li>
     <li class="pure-menu-item"><a href="#" class="pure-menu-link api-section-link" onclick="openSection(event, 'outputquantities')">Output quantities</a></li>

--- a/doc/templates/examples-template.html
+++ b/doc/templates/examples-template.html
@@ -222,7 +222,7 @@ saveas(geom, "imageShape")
 
 Note: these are 3D geometries seen from above. The displayed cell filling is averaged along the thickness (notable in ellipse and layers example). Black means empty space, white is filled.
 
-<hr/><h2 id="ex_initmag">Initial Magnetization</h2>
+<hr/><h2 id="ex_initmag">Initial magnetization</h2>
 Some initial magnetization functions are provided, as well as transformations similar to those on Shapes. See the Config <a href="http://mumax.github.io/api.html">API</a>.
 
 {{.Example `
@@ -280,7 +280,7 @@ These initial states are approximate, after setting them it is a good idea to re
 The magnetization can also be set in separate regions, see below.
 
 
-<hr/><h2 id="ex_cheese">Interlude: Rotating Cheese</h2>
+<hr/><h2 id="ex_cheese">Interlude: rotating cheese</h2>
 
 In this example we define a geometry that looks like a slice of cheese and have it rotate in time.
 
@@ -317,7 +317,7 @@ for i:=0; i<=90; i=i+30{
 {{.Output}}
 
 
-<hr/><h2 id="ex_regions">Regions: Space-dependent Parameters</h2>
+<hr/><h2 id="ex_regions">Regions: space-dependent parameters</h2>
 
 <p>Space-dependent parameters are defined using material <i>regions</i>. Regions are numbered 0-255 and represent different materials. Each cell can belong to only one region. At the start of a simulation all cells have region number 0.</p>
 
@@ -429,7 +429,7 @@ saveas(MFM, "lift_90nm")
 {{.Output}}
 
 
-<hr/><h2 id="ex_PMA">PMA Racetrack</h2>
+<hr/><h2 id="ex_PMA">PMA racetrack</h2>
 In this example we drive a domain wall in PMA material by spin-transfer torque.  We set up a post-step function that makes the simulation box "follow" the domain wall. Like this, only a small number of cells is needed to simulate an infinitely long magnetic wire.
 
 {{.Example `
@@ -463,7 +463,7 @@ run(.5e-9)
 Since we center on the domain wall we can not see that it is actually moving, but the domain wall breakdown is visible.
 
 
-<hr/><h2 id="ex_Py">Py Racetrack</h2>
+<hr/><h2 id="ex_Py">Py racetrack</h2>
 
 In this example we drive a vortex wall in Permalloy by spin-transfer torque. The simulation box "follows" the domain wall. By removing surface charges at the left and right ends, we mimic an infintely long wire.
 

--- a/engine/shape.go
+++ b/engine/shape.go
@@ -30,6 +30,7 @@ func init() {
 	DeclFunc("Universe", Universe, "Entire space")
 	DeclFunc("Cell", Cell, "Single cell with given integer index (i, j, k)")
 	DeclFunc("ImageShape", ImageShape, "Use black/white image as shape")
+	DeclFunc("VoxelShape", VoxelShape, "Use slice (ScalarMask) of rectangular cells (with size defined by second argument) as a 3D object")
 	DeclFunc("GrainRoughness", GrainRoughness, "Grainy surface with different heights per grain "+
 		"with a typical grain size (first argument), minimal height (second argument), and maximal "+
 		"height (third argument). The last argument is a seed for the random number generator.")

--- a/engine/shape.go
+++ b/engine/shape.go
@@ -30,7 +30,7 @@ func init() {
 	DeclFunc("Universe", Universe, "Entire space")
 	DeclFunc("Cell", Cell, "Single cell with given integer index (i, j, k)")
 	DeclFunc("ImageShape", ImageShape, "Use black/white image as shape")
-	DeclFunc("VoxelShape", VoxelShape, "Use slice (ScalarMask) of rectangular cells (with size defined by second argument) as a 3D object")
+	DeclFunc("VoxelShape", VoxelShape, "Use slice (ScalarMask containing 0s and 1s) of rectangular cells (with size defined by last 3 arguments) as a 3D object")
 	DeclFunc("GrainRoughness", GrainRoughness, "Grainy surface with different heights per grain "+
 		"with a typical grain size (first argument), minimal height (second argument), and maximal "+
 		"height (third argument). The last argument is a seed for the random number generator.")

--- a/test/voxelshape.mx3
+++ b/test/voxelshape.mx3
@@ -1,0 +1,42 @@
+Nx := 64
+Ny := 64
+Nz := 32
+cs := 5e-9
+
+SetGridSize(Nx, Ny, Nz)
+SetCellSize(cs, cs, cs)
+
+d := 100e-9
+mask := NewScalarMask(Nx, Ny, Nz)
+for i := 0; i < Nx; i++ {
+	for j := 0; j < Ny; j++ {
+		for k := 0; k < Nz; k++ {
+			r := index2coord(i, j, k)
+			x2 := pow(r.X(), 2)
+			y2 := pow(r.Y(), 2)
+			z2 := pow(r.Z(), 2)
+			if pow((x2+y2+z2), 0.5) < d/2 {
+				mask.Set(0, i, j, k, 1)
+			}
+		}
+	}
+}
+
+geomfrommask := VoxelShape(mask, 5e-9, 5e-9, 5e-9)
+SetGeom(geomfrommask)
+
+m.setInShape(geomfrommask, Uniform(1, 0, 0)) // Setup for checks: set m in VoxelShape
+
+// Sphere shape should equal the created VoxelShape 
+SetGeom(Ellipsoid(d, d, d))
+ExpectV("Same shape m_avg", m.Average(), Vector(1, 0, 0), 0)
+
+// Bigger than VoxelShape: random magnetization gets included
+SetGeom(Ellipsoid(d, d, 3*d/2))
+ExpectV("Too large m_avg", m.Average(), Vector(0.6658, -0.00345, 0.00593), 1e-5)
+print(m.Average())
+
+// Change cell size to see if voxels scale along
+SetCellSize(cs/2, cs/2, cs)
+SetGeom(geomfrommask)
+ExpectV("New cellsize m_avg", m.Average(), Vector(0.25808, -0.00174, 0.00508), 1e-5)


### PR DESCRIPTION
In 3.11, Voxelshape was restricted from users. However, while the description says 'array', it actually works with slices. In particular, it works with slices created with NewScalarMask, with no other changes needed (surprisingly, no changes were needed to manage GPUAccess/CPUAccess at all). This can probably be safely re-exposed to the user? A minimal working example is attached: 
[testvoxel.txt](https://github.com/user-attachments/files/26085155/testvoxel.txt)
