### PR TITLE
Allows odd N mesh for nonzero Temp

### DIFF
--- a/cuda/curand/generator.go
+++ b/cuda/curand/generator.go
@@ -49,4 +49,11 @@ func (g Generator) SetSeed(seed int64) {
 	}
 }
 
+func (g Generator) SetOffset(offset int64) {
+	err := Status(C.curandSetGeneratorOffset(C.curandGenerator_t(unsafe.Pointer(uintptr(g))), C.ulonglong(offset)))
+	if err != SUCCESS {
+		panic(err)
+	}
+}
+
 // Documentation was taken from the curand headers.

--- a/cuda/temperature.go
+++ b/cuda/temperature.go
@@ -8,6 +8,8 @@ import (
 // Set Bth to thermal noise (Brown).
 // see temperature2.cu
 func SetTemperature(Bth, noise *data.Slice, k2mu0_Mu0VgammaDt float64, Msat, Temp, Alpha MSlice) {
+
+	// N is set by the length of Bth. noise is now set to length N+N%2 (N when N is even, N+1 when N is odd) in engine/temperature.go, so noise[N] is a dummy value that should never be used. The kernel only cares about the underlying pointer and the explicit N count, not the declared shape.
 	util.Argument(Bth.NComp() == 1 && noise.NComp() == 1)
 
 	N := Bth.Len()

--- a/engine/temperature.go
+++ b/engine/temperature.go
@@ -28,8 +28,8 @@ type thermField struct {
 }
 
 func init() {
-	DeclFunc("ThermSeed", ThermSeed, "Deprecated: use NewThermSeed() instead.<br>ThermSeed() sets a random seed for thermal noise, but does not reset the RNG offset, yielding different noise even for the same seed. This function remains here to ensure backwards compatibility with mumax3.12 and earlier.")
-	DeclFunc("NewThermSeed", NewThermSeed, "Set a random seed for thermal noise")
+	DeclFunc("ThermSeed", ThermSeed, "Deprecated: use ThermReseed() instead.<br>ThermSeed() sets a random seed for thermal noise, but does not reset the RNG offset, yielding different noise even for the same seed. This function remains here to ensure backwards compatibility with mumax3.12 and earlier.")
+	DeclFunc("ThermReseed", ThermReseed, "Set a random seed for thermal noise")
 	registerEnergy(GetThermalEnergy, AddThermalEnergyDensity)
 	B_therm.step = -1 // invalidate noise cache
 	DeclROnly("B_therm", &B_therm, "Thermal field (T)")
@@ -130,7 +130,7 @@ func GetThermalEnergy() float64 {
 
 // Seeds the thermal noise generator
 func ThermSeed(seed int) {
-	warnStr := " WARNING: ThermSeed() is deprecated. Use NewThermSeed() instead.\n" + // First "//" gets added by LogOut()
+	warnStr := " WARNING: ThermSeed() is deprecated. Use ThermReseed() instead.\n" + // First "//" gets added by LogOut()
 		"//          (ThermSeed does not guarantee identical noise after each call\n" +
 		"//           because it only resets the RNG seed, not the RNG offset.)"
 	LogOut(warnStr)
@@ -140,7 +140,7 @@ func ThermSeed(seed int) {
 	}
 }
 
-func NewThermSeed(seed int) {
+func ThermReseed(seed int) {
 	B_therm.seed = int64(seed)
 	if B_therm.generator != 0 {
 		B_therm.generator.SetOffset(0)

--- a/engine/temperature.go
+++ b/engine/temperature.go
@@ -28,7 +28,8 @@ type thermField struct {
 }
 
 func init() {
-	DeclFunc("ThermSeed", ThermSeed, "Set a random seed for thermal noise")
+	DeclFunc("ThermSeed", ThermSeed, "Deprecated: use NewThermSeed() instead.<br>ThermSeed() sets a random seed for thermal noise, but does not reset the RNG offset, yielding different noise even for the same seed. This function remains here to ensure backwards compatibility with mumax3.12 and earlier.")
+	DeclFunc("NewThermSeed", NewThermSeed, "Set a random seed for thermal noise")
 	registerEnergy(GetThermalEnergy, AddThermalEnergyDensity)
 	B_therm.step = -1 // invalidate noise cache
 	DeclROnly("B_therm", &B_therm, "Thermal field (T)")
@@ -129,8 +130,20 @@ func GetThermalEnergy() float64 {
 
 // Seeds the thermal noise generator
 func ThermSeed(seed int) {
+	warnStr := " WARNING: ThermSeed() is deprecated. Use NewThermSeed() instead.\n" + // First "//" gets added by LogOut()
+		"//          (ThermSeed does not guarantee identical noise after each call\n" +
+		"//           because it only resets the RNG seed, not the RNG offset.)"
+	LogOut(warnStr)
 	B_therm.seed = int64(seed)
 	if B_therm.generator != 0 {
+		B_therm.generator.SetSeed(B_therm.seed)
+	}
+}
+
+func NewThermSeed(seed int) {
+	B_therm.seed = int64(seed)
+	if B_therm.generator != 0 {
+		B_therm.generator.SetOffset(0)
 		B_therm.generator.SetSeed(B_therm.seed)
 	}
 }

--- a/engine/temperature.go
+++ b/engine/temperature.go
@@ -1,15 +1,12 @@
 package engine
 
 import (
-	"fmt"
-
 	"math"
 
 	"github.com/mumax/3/cuda"
 	"github.com/mumax/3/cuda/curand"
 	"github.com/mumax/3/data"
 	"github.com/mumax/3/mag"
-	"github.com/mumax/3/util"
 )
 
 var (
@@ -20,7 +17,6 @@ var (
 )
 
 var AddThermalEnergyDensity = makeEdensAdder(&B_therm, -1)
-var PrintedWarningTempOddGrid = false // Will be set to true if the warning about odd temperature has been printed already, to avoid spam.
 
 // thermField calculates and caches thermal noise.
 type thermField struct {
@@ -91,15 +87,18 @@ func (b *thermField) update() {
 	}
 
 	N := Mesh().NCell()
-	if !PrintedWarningTempOddGrid && N%2 > 0 { // T is nonzero if we have gotten this far. As noted in issue #314, this means the grid size must be even.
-		PrintedWarningTempOddGrid = true
-		warnStr := "// WARNING: nonzero temperature requires an even amount of grid cells,\n" +
-			"//          but all axes have an odd number of cells: %v.\n" +
-			"//          This may cause a CURAND_STATUS_LENGTH_NOT_MULTIPLE error." // Error is likely when the largest factor is >127
-		util.Log(fmt.Sprintf(warnStr, Mesh().Size()))
-	}
+
+	// CURAND's GenerateNormal uses Box-Muller, which requires an even length. If N is odd, we allocate
+	// one extra float so CURAND is satisfied. The settemperature2 kernel guards
+	// on i < N (derived from B's size, not noise's size), so noise[N] is written but never read.
+	Npad := int64(N + (N % 2))
 	k2_VgammaDt := 2 * mag.Kb / (GammaLL * cellVolume() * Dt_si)
-	noise := cuda.Buffer(1, Mesh().Size())
+
+	// Use the exact mesh shape when N is already even (common case, no overhead), equivalent to Mesh().Size()
+	// When N is odd, use a flat [Npad,1,1] shape — the Cuda kernel only cares about
+	// the underlying pointer and the explicit N count, not the declared shape.
+	noise := cuda.Buffer(1, [3]int{int(Npad), 1, 1})
+
 	defer cuda.Recycle(noise)
 
 	const mean = 0
@@ -112,7 +111,7 @@ func (b *thermField) update() {
 	alpha := Alpha.MSlice()
 	defer alpha.Recycle()
 	for i := 0; i < 3; i++ {
-		b.generator.GenerateNormal(uintptr(noise.DevPtr(0)), int64(N), mean, stddev)
+		b.generator.GenerateNormal(uintptr(noise.DevPtr(0)), Npad, mean, stddev)
 		cuda.SetTemperature(dst.Comp(i), noise, k2_VgammaDt, ms, temp, alpha)
 	}
 

--- a/test/thermalnoise-odd.mx3
+++ b/test/thermalnoise-odd.mx3
@@ -25,7 +25,7 @@ Alpha = 0.02
 Temp = 300
 FixDt = 1e-13
 
-NewThermSeed(SEED)
+ThermReseed(SEED)
 steps(1)
 B_therm.EvalTo(s)
 
@@ -43,7 +43,7 @@ Nz = 2
 SetGridSize(3, 3, Nz) // N = 18, one axis even
 s = NewVectorMask(3, 3, Nz)
 
-NewThermSeed(SEED)
+ThermReseed(SEED)
 steps(1)
 B_therm.EvalTo(s)
 

--- a/test/thermalnoise-odd.mx3
+++ b/test/thermalnoise-odd.mx3
@@ -1,0 +1,54 @@
+/*  Since cuRAND can only generate an even number of random values in parallel,
+    simulations with an odd number of cells N generate N+1 random thermal noise
+    values per vector component. Hence, in every step, the last generated value
+    for each componoent is discared in simulations wiht an odd number of cells.
+
+    This test compares the thermal noise of a 3x3x3 and 3x3x2 system, to check
+    whether the thermal noise follows the expected order for such trunction.
+    This also implicitly tests whether ThermSeed() fully resets the generated
+    sequence, as well as checking whether the absolute values of the generated
+    elements remain the same across GPUs and into future mumax³ versions.
+*/
+
+SEED := 42
+
+
+//// ODD NUMBER OF CELLS
+Nz := 3
+SetGridSize(3, 3, Nz) // N = 27, all axes odd
+s := NewVectorMask(3, 3, Nz)
+
+SetCellSize(5e-9, 5e-9, 5e-9)
+Msat = 8e5
+Aex = 11e-12
+Alpha = 0.02
+Temp = 300
+FixDt = 1e-13
+
+NewThermSeed(SEED)
+steps(1)
+B_therm.EvalTo(s)
+
+VAL1 := s.Get(0, 0, 0, 0) // 3x3x3 idx=0 X-comp after 1 step --> 28*3 = 84 numbers previously generated
+VAL2 := s.Get(1, 0, 0, 0) // 3x3x3 idx=0 Y-comp after 1 step --> 28*4 = 112 numbers previously generated
+VAL3 := s.Get(2, 0, 0, 0) // 3x3x3 idx=0 Z-comp after 1 step --> 28*5 = 140 numbers previously generated
+
+Expect(sprintf("Seed %d: 85th thermal noise element", SEED), VAL1, 0.160713791847229, 0)
+Expect(sprintf("Seed %d: 113th thermal noise element", SEED), VAL2, 0.11215255409479141, 0)
+Expect(sprintf("Seed %d: 141st thermal noise element", SEED), VAL3, 0.3278733491897583, 0)
+
+
+//// EVEN NUMBER OF CELLS
+Nz = 2
+SetGridSize(3, 3, Nz) // N = 18, one axis even
+s = NewVectorMask(3, 3, Nz)
+
+NewThermSeed(SEED)
+steps(1)
+B_therm.EvalTo(s)
+
+Expect("Thermal noise Y idx 12 after 1 step", s.Get(1, 0, 1, 1), VAL1, 0) // 84 numbers previously generated = 3*18 (1 step) + 18 (1 comp) + 9 (Z=1) + 3 (Y=1)
+steps(1)
+B_therm.EvalTo(s)
+Expect("Thermal noise X idx 4 after 2 steps", s.Get(0, 1, 1, 0), VAL2, 0) // 112 numbers previously generated = 6*18 (2 steps) + 3 (Y=1) + 1 (X=1)
+Expect("Thermal noise Y idx 14 after 2 steps", s.Get(1, 2, 1, 1), VAL3, 0) // 140 numbers previously generated = 6*18 (2 steps) + 18 (1 comp) + 9 (Z=1) + 3 (Y=1) + 2 (X=2)


### PR DESCRIPTION
Hi,

This PR adds support for using odd grids with temperature enabled. Previously, N (N=Nx*Ny*Nz) was required to be even when temperature was nonzero, due to Curand's use of the Box-Muller algorithm which produces random values in pairs. Essentially the same as the mumaxplus fix (https://github.com/mumax/plus/pull/155). 

Instead of doing a cuda memcpy, it is done by the existing cuda kernel. In the cuda kernel the size of B_th and noise for the purpose of the kernel uses size of B_th, so since B_th is size N and noise is size N+1, the kernel uses N, and the final float inside noise is essentially invisible and unused. 

In that discussion, there were some concerns over speed and memory usage when using a buffer instead of just writing the values directly. Mumax3 currently uses a buffer. The speed difference was negligible. For a test grid size of ~515x515x55, there is a memory savings of ~ 53 MB for directly writing, or 0.9% of the ~6GB total memory required for the simulation. This seemed small enough that I just kept the buffer method for both N even or odd, since it seems a bit cleaner. The biggest concern is that some future change might accidentally use the N+1 size of noise, but the noise buffer doesn't get touched in the code outside of this section, so the odds of the N+1 size being unintentionally used elsewhere in a future update is small. (I spent a little bit of time trying to see if I could get mumaxplus to avoid needing the buffer for odd N, but it's structured a little differently, seems like it'd be a bit more of a headache to track the hidden float.)

When reviewing, probably the two big things to check is there is no unintentional buffer overflow, and that the N+1 value never gets used unintentionally, but given how noise is used I think I avoided that.

This does mean that for generated values in the stream in N odd simulations, 1 float gets consumed without being used per component, per time step. Otherwise the random value streams line up exactly as before, as expected. As example, I've attached an example script along with a few ovf files for a grid of 3x3x3 and 3x3x2. They match exactly up until the value 0.14437014 (missing from step0 3x3x3. this also corresponds exactly to the bottom of the first column/top of the second column). You see the same thing in future steps, every 3x3x3+1=27+1th value gets skipped, as expected, but otherwise the stream values match exactly.

[oddtest.txt](https://github.com/user-attachments/files/28923918/oddtest.txt)
[Thermal field000000_332.txt](https://github.com/user-attachments/files/28923919/Thermal.field000000_332.txt)
[Thermal field000000_333.txt](https://github.com/user-attachments/files/28923920/Thermal.field000000_333.txt)
[Thermal field000001_332.txt](https://github.com/user-attachments/files/28923921/Thermal.field000001_332.txt)
[Thermal field000001_333.txt](https://github.com/user-attachments/files/28923922/Thermal.field000001_333.txt)


I didn't include a test script, but the example could probably be converted to one fairly easily if it's worth it.

Best regards,
Josh L.