### PR TITLE
Make reduction operations deterministic

### DIFF
--- a/cuda/init.go
+++ b/cuda/init.go
@@ -47,6 +47,8 @@ func Init(gpu int) {
 		log.Println("DEBUG: synchronized CUDA calls")
 	}
 
+	reducecfg = &config{Grid: cu.Dim3{X: cu.DeviceGetAttribute(cu.MULTIPROCESSOR_COUNT, dev), Y: 1, Z: 1}, Block: cu.Dim3{X: REDUCE_BLOCKSIZE, Y: 1, Z: 1}}
+
 	// test PTX load so that we can catch CUDA_ERROR_NO_BINARY_FOR_GPU early
 	fatbinLoad(madd2_map, "madd2")
 }

--- a/cuda/reduce.go
+++ b/cuda/reduce.go
@@ -18,9 +18,16 @@ const REDUCE_BLOCKSIZE = C.REDUCE_BLOCKSIZE
 // Sum of all elements.
 func Sum(in *data.Slice) float32 {
 	util.Argument(in.NComp() == 1)
-	out := reduceBuf(0)
-	k_reducesum_async(in.DevPtr(0), out, 0, in.Len(), reducecfg)
-	return copyback(out)
+	partials := reduceBufN(reducecfg.nBlocks(), 0)
+	k_reducesum_async(in.DevPtr(0), partials, 0, in.Len(), reducecfg)
+	host := copybackSlice(partials, reducecfg.nBlocks())
+
+	// Add elements of partials on CPU
+	var result float32
+	for _, v := range host {
+		result += v
+	}
+	return result
 }
 
 // Dot product.

--- a/cuda/reduce.go
+++ b/cuda/reduce.go
@@ -137,6 +137,5 @@ func initReduceBuf() {
 }
 
 // launch configuration for reduce kernels
-// 8 is typ. number of multiprocessors.
-// could be improved but takes hardly ~1% of execution time
-var reducecfg = &config{Grid: cu.Dim3{X: 8, Y: 1, Z: 1}, Block: cu.Dim3{X: REDUCE_BLOCKSIZE, Y: 1, Z: 1}}
+// Grid size is set during cuda.Init to equal the number of multiprocessors.
+var reducecfg *config

--- a/cuda/reduce.go
+++ b/cuda/reduce.go
@@ -27,12 +27,19 @@ func Sum(in *data.Slice) float32 {
 func Dot(a, b *data.Slice) float32 {
 	nComp := a.NComp()
 	util.Argument(nComp == b.NComp())
-	out := reduceBuf(0)
+	partials := reduceBufN(reducecfg.nBlocks(), 0)
 	// not async over components
 	for c := 0; c < nComp; c++ {
-		k_reducedot_async(a.DevPtr(c), b.DevPtr(c), out, 0, a.Len(), reducecfg) // all components add to out
+		k_reducedot_async(a.DevPtr(c), b.DevPtr(c), partials, 0, a.Len(), reducecfg) // all components add to out
 	}
-	return copyback(out)
+	host := copybackSlice(partials, reducecfg.nBlocks())
+
+	// Add elements of partials on CPU
+	var result float32
+	for _, v := range host {
+		result += v
+	}
+	return result
 }
 
 // Maximum of absolute values of all elements.
@@ -65,7 +72,8 @@ func MaxVecDiff(x, y *data.Slice) float64 {
 	return math.Sqrt(float64(copyback(out)))
 }
 
-var reduceBuffers chan unsafe.Pointer // pool of 1-float CUDA buffers for reduce
+var reduceBuffers chan unsafe.Pointer                // pool of 1-float CUDA buffers for reduce
+var reduceBuffersN = map[int64]chan unsafe.Pointer{} // pool of N-float CUDA buffers for reduce
 
 // return a 1-float CUDA reduction buffer from a pool
 // initialized to initVal
@@ -78,6 +86,24 @@ func reduceBuf(initVal float32) unsafe.Pointer {
 	return buf
 }
 
+// return an N-float CUDA reduction buffer from a pool
+// initialized to initVal
+func reduceBufN(N int64, initVal float32) unsafe.Pointer {
+	const Nbufs = 128
+	q, ok := reduceBuffersN[N]
+	if !ok { // Create buffer channel for this N if it doesn't exist
+		q = make(chan unsafe.Pointer, Nbufs)
+		for i := 0; i < Nbufs; i++ {
+			q <- MemAlloc(N * cu.SIZEOF_FLOAT32)
+		}
+		reduceBuffersN[N] = q
+	}
+
+	buf := <-q
+	cu.MemsetD32Async(cu.DevicePtr(uintptr(buf)), math.Float32bits(initVal), N, stream0)
+	return buf
+}
+
 // copy back single float result from GPU and recycle buffer
 func copyback(buf unsafe.Pointer) float32 {
 	var result float32
@@ -86,11 +112,19 @@ func copyback(buf unsafe.Pointer) float32 {
 	return result
 }
 
+// copy back a slice of length N from GPU
+func copybackSlice(buf unsafe.Pointer, N int64) []float32 {
+	result := make([]float32, N)
+	MemCpyDtoH(unsafe.Pointer(&result[0]), buf, N*cu.SIZEOF_FLOAT32)
+	reduceBuffersN[N] <- buf
+	return result
+}
+
 // initialize pool of 1-float CUDA reduction buffers
 func initReduceBuf() {
-	const N = 128
-	reduceBuffers = make(chan unsafe.Pointer, N)
-	for i := 0; i < N; i++ {
+	const Nbufs = 128
+	reduceBuffers = make(chan unsafe.Pointer, Nbufs)
+	for i := 0; i < Nbufs; i++ {
 		reduceBuffers <- MemAlloc(1 * cu.SIZEOF_FLOAT32)
 	}
 }

--- a/cuda/reduce.h
+++ b/cuda/reduce.h
@@ -4,6 +4,42 @@
 // Block size for reduce kernels.
 #define REDUCE_BLOCKSIZE 512
 
+// Same as reduce, but without atomicOp now such that it is deterministic.
+#define reduceDeterministic(load, op)                   \
+    __shared__ float sdata[REDUCE_BLOCKSIZE];           \
+    int tid = threadIdx.x;                              \
+    int i =  blockIdx.x * blockDim.x + threadIdx.x;     \
+                                                        \
+    float mine = initVal;                               \
+    int stride = gridDim.x * blockDim.x;                \
+    while (i < n) {                                     \
+        mine = op(mine, load(i));                       \
+        i += stride;                                    \
+    }                                                   \
+    sdata[tid] = mine;                                  \
+    __syncthreads();                                    \
+                                                        \
+    for (unsigned int s=blockDim.x/2; s>32; s>>=1) {    \
+        if (tid < s){                                   \
+            sdata[tid] = op(sdata[tid], sdata[tid + s]);\
+        }                                               \
+        __syncthreads();                                \
+    }                                                   \
+                                                        \
+    if (tid < 32) {                                     \
+        volatile float* smem = sdata;                   \
+        smem[tid] = op(smem[tid], smem[tid + 32]);      \
+        smem[tid] = op(smem[tid], smem[tid + 16]);      \
+        smem[tid] = op(smem[tid], smem[tid +  8]);      \
+        smem[tid] = op(smem[tid], smem[tid +  4]);      \
+        smem[tid] = op(smem[tid], smem[tid +  2]);      \
+        smem[tid] = op(smem[tid], smem[tid +  1]);      \
+    }                                                   \
+                                                        \
+    if (tid == 0) {                                     \
+        dst[blockIdx.x] = op(dst[blockIdx.x], sdata[0]);\
+    }                                                   \
+
 // This macro expands to a reduce kernel with arbitrary reduce operation.
 // Ugly, perhaps, but arguably nicer than some 1000+ line C++ template.
 // load(i): loads element i, possibly pre-processing the data

--- a/cuda/reducedot.cu
+++ b/cuda/reducedot.cu
@@ -6,6 +6,6 @@
 extern "C" __global__ void
 reducedot(float* __restrict__ x1, float* __restrict__ x2,
           float*__restrict__  dst, float initVal, int n) {
-    reduce(load_prod, sum, atomicAdd)
+    reduceDeterministic(load_prod, sum)
 }
 

--- a/cuda/reducesum.cu
+++ b/cuda/reducesum.cu
@@ -5,6 +5,6 @@
 
 extern "C" __global__ void
 reducesum(float* __restrict__ src, float*__restrict__  dst, float initVal, int n) {
-    reduce(load, sum, atomicAdd)
+    reduceDeterministic(load, sum)
 }
 

--- a/cuda/util.go
+++ b/cuda/util.go
@@ -2,6 +2,7 @@ package cuda
 
 import (
 	"fmt"
+
 	"github.com/mumax/3/cuda/cu"
 )
 
@@ -17,6 +18,11 @@ const (
 // cuda launch configuration
 type config struct {
 	Grid, Block cu.Dim3
+}
+
+// Number of blocks in the CUDA launch grid.
+func (c config) nBlocks() int64 {
+	return int64(c.Grid.X) * int64(c.Grid.Y) * int64(c.Grid.Z)
 }
 
 // Make a 1D kernel launch configuration suited for N threads.


### PR DESCRIPTION
As reported in #329 and several times on the mailing list, `minimize()` could give different results on the same hardware when running the exact same script multiple times.

The reason for this, it turns out, is the nonassociativity of floating-point calculation.
The minimizer uses `cuda.Dot`, which is a reduction operation. In mumax³, reductions are calculated on the GPU in 8 parallel blocks, the results of each of which are then added together to obtain the final result. However, depending on which block finishes first, these values can be added in a different order, potentially yielding different results due to the aforementioned nonassociativity. 

This also affected `cuda.Sum`, which for example caused slight variations in `E_anis`, as demonstrated by this small example script:

```go
SetCellSize(4e-9, 4e-9, 4e-9)
SetGridSize(128, 128, 2)
Msat = 800e3
Ku1 = 1e5
AnisU = Vector(1, 0, 0)
m = RandomMagSeed(2)
print(E_anis)
```

This effect does not seem to be present in the other reduction operations of `cuda/reduce.go`, since they all return a maximum value and are therefore not affected by the nonassociativity.

### Solution

A new macro `reduceDeterministic` can now is now used by the affected CUDA kernels, that is largely similar to the existing `reduce` except that it populates an array of values (with length = number of blocks) rather than a single scalar value. On the Go side, the relevant functions then simply add the elements of this array in their order of appearance, yielding a deterministic value due to the indexing used. It seems that this has a negligible performance impact.

### Possible improvements

The aggregate values of each block could also be sorted in ascending order, to perform the most accurate floating-point addition possible. However, this would incur additional overhead, and would in practice not actually contribute to bringing results across different GPUs closer together, so I don't think sorting is useful.

An alternative solution could be to [specify the determinism level](https://developer.nvidia.com/blog/controlling-floating-point-determinism-in-nvidia-cccl), as suggested by @jplauzie elsewhere, but this seems to have a more noticeable performance impact.

Also, instead of 8 blocks, the number of blocks could be increased to equal the number of multiprocessors on the GPU. I believe the currently used value of 8 might just have been a typical number for the GPUs at the time mumax³ was written. I am not sure how much this would affect performance and which amount of blocks would be ideal.
> Update: it seems that using an equal amount of blocks as there are SM's on the GPU, as was ultimately implemented in this PR, results in a >2% speedup of `minimize()` overall (for a 2048x2048 simulation; smaller systems experience a smaller performance increase).